### PR TITLE
use the mongodb cursor for the count to prevent double queries

### DIFF
--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/ODM/MongoDB/QuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/ODM/MongoDB/QuerySubscriber.php
@@ -11,8 +11,6 @@ class QuerySubscriber implements EventSubscriberInterface
     public function items(ItemsEvent $event)
     {
         if ($event->target instanceof Query) {
-            // count
-            $event->count = $event->target->count();
             // items
             $type = $event->target->getType();
             if ($type !== Query::TYPE_FIND) {
@@ -32,6 +30,9 @@ class QuerySubscriber implements EventSubscriberInterface
             $resultQuery = clone $event->target;
             $reflectionProperty->setValue($resultQuery, $queryOptions);
             $cursor = $resultQuery->execute();
+
+            // set the count from the cursor
+            $event->count = $cursor->count();
 
             $event->items = $cursor->toArray();
             $event->stopPropagation();


### PR DESCRIPTION
calling count() on the Query was resulting in a second identical find(). It's better to get the count from the mongo cursor as it disregards the limit and skip anyway.
