### PR TITLE
remove check for field existing. not required for ODM.

### DIFF
--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/Doctrine/ODM/MongoDB/QuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/Doctrine/ODM/MongoDB/QuerySubscriber.php
@@ -16,10 +16,6 @@ class QuerySubscriber implements EventSubscriberInterface
                 $field = $_GET[$alias.'sort'];
                 $dir = strtolower($_GET[$alias.'direction']) == 'asc' ? 1 : -1;
 
-                $meta = $event->target->getClass();
-                if (!$meta->hasField($field)) {
-                    throw new \UnexpectedValueException($meta->name.' query cannot be sorted, because does not contain field: '.$field);
-                }
                 if (isset($event->options['whitelist'])) {
                     if (!in_array($field, $event->options['whitelist'])) {
                         throw new \UnexpectedValueException("Cannot sort by: [{$field}] this field is not in whitelist");


### PR DESCRIPTION
I don't see a need to check if the field exists as mongo will gladly sort by anything you give it. And that's sometimes a desirable feature.

Specifically, the problem I ran into was with single-collection inheritance. The BaseClass was the target object which didn't explicitly contain the field i was sorting on as it was in some of the inherited classes instead. As a result, this exception was thrown. Everything works as expected without this check.
