### PR TITLE
Fix offsetSet method implementation

### DIFF
--- a/src/Knp/Component/Pager/Pagination/AbstractPagination.php
+++ b/src/Knp/Component/Pager/Pagination/AbstractPagination.php
@@ -147,22 +147,26 @@ abstract class AbstractPagination implements PaginationInterface, Countable, Ite
     {
         return $this->items;
     }
-    
+
     public function offsetExists($offset) 
     {
         return array_key_exists($offset, $this->items);
     }
-    
+
     public function offsetGet($offset) 
     {
         return $this->items[$offset];
     }
-    
+
     public function offsetSet($offset, $value) 
     {
-        $this->items[$offset] = $value;
+        if (null === $offset) {
+            $this->items[] = $value;
+        } else {
+            $this->items[$offset] = $value;
+        }
     }
-    
+
     public function offsetUnset($offset) 
     {
         unset($this->items[$offset]);


### PR DESCRIPTION
calling `$pagination[] = $something;` will pass `NULL` to `$offset`
parameter of `offsetSet` method, and calling `$this->items[NULL] = $value`
will end with empty string as index, and may lead to overriding values

Plus I've removed some trailing spaces :)
