### PR TITLE
One solr query in SolariumQuerySubscrber instead two

### DIFF
--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/SolariumQuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/SolariumQuerySubscriber.php
@@ -17,16 +17,12 @@ class SolariumQuerySubscriber implements EventSubscriberInterface
         if (is_array($event->target) && 2 === count($event->target) && isset($event->target[0], $event->target[1]) &&
             $event->target[0] instanceof \Solarium_Client && $event->target[1] instanceof \Solarium_Query_Select) {
                 list($client, $query) = $event->target;
-                $results = array();
-                $event->count = $client->select($query)->getNumFound();
-                if ($event->count) {
-                    $query
-                        ->setStart($event->getOffset())
-                        ->setRows($event->getLimit())
-                    ;
-                    $results = $client->select($query)->getIterator();
-                }
-                $event->items = $results;
+
+                $query->setStart($event->getOffset())->setRows($event->getLimit());
+                $solrResult = $client->select($query);
+
+                $event->items = $solrResult->getIterator();
+                $event->count = $solrResult->getNumFound();
                 $event->stopPropagation();
         }
     }


### PR DESCRIPTION
Why we need two solr queries if we able to get num found from one request
