### PR TITLE
Support for Doctrine version < 2.4.*-dev

### DIFF
--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/ORM/QuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/ORM/QuerySubscriber.php
@@ -81,7 +81,27 @@ class QuerySubscriber implements EventSubscriberInterface
                         ->setFirstResult(null)
                         ->setMaxResults(null)
                     ;
-                    $whereInQuery->setParameter(WhereInWalker::PAGINATOR_ID_ALIAS, $ids);
+                        
+                    if(version_compare(\Doctrine\ORM\Version::VERSION, '2.4.0', '>=')) {
+                        $whereInQuery->setParameter(WhereInWalker::PAGINATOR_ID_ALIAS, $ids);
+                    }
+                    else {
+                        $type = $limitSubQuery->getHint($useDoctrineWalkers ?
+                            DoctrineLimitSubqueryWalker::IDENTIFIER_TYPE :
+                            LimitSubqueryWalker::IDENTIFIER_TYPE
+                        );
+                        $idAlias = $useDoctrineWalkers ? 
+                            DoctrineWhereInWalker::PAGINATOR_ID_ALIAS : 
+                            WhereInWalker::PAGINATOR_ID_ALIAS
+                        ;
+                        foreach ($ids as $i => $id) {
+                            $whereInQuery->setParameter(
+                                $idAlias . '_' . ++$i,
+                                $id,
+                                $type->getName()
+                            );
+                        }
+                    }
                     $result = $whereInQuery->execute();
                 } else {
                     $event->target


### PR DESCRIPTION
Fixes commit https://github.com/KnpLabs/knp-components/commit/19923c5b707bd13b470131040c56d873e2998cf6

So component could be used with older Doctrine versions.
