### PR TITLE
Bugfix: Add Collection to array conversion.

### DIFF
--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/CollectionSubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/CollectionSubscriber.php
@@ -16,7 +16,7 @@ class CollectionSubscriber implements EventSubscriberInterface
             $event->items = new ArrayObject($event->target->slice(
                 $event->getOffset(),
                 $event->getLimit()
-            ));
+            )->toArray());
             $event->stopPropagation();
         }
     }


### PR DESCRIPTION
ArrayObject requires array only to work properly.
Correct data structure in paginator ArrayObject:
[Entity, Entity, Entity]
Current data structure in paginator ArrayObject:
[0 => Collection([Entity, Entity, Entity])]