### PR TITLE
Change count condition for only one object

### DIFF
--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/ORM/QuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/ORM/QuerySubscriber.php
@@ -61,7 +61,7 @@ class QuerySubscriber implements EventSubscriberInterface
                 ;
 
                 $countResult = $countQuery->getResult(Query::HYDRATE_ARRAY);
-                if (count($countResult) > 1) {
+                if (count($countResult) >= 1) {
                     $countResult = count($countResult);
                 } else {
                     $countResult = current($countResult);


### PR DESCRIPTION
I suggest this PR if I pass a Doctrine ORM Query which will return only one result to your pager, the counter while try to get the first property of this result.

In my case, there is the var_dump of `$countReslut` before the modified condition:

```
array(1) {
  [0]=>
  &array(13) {
    ["id"]=>
    int(9122)
    ["slug"]=>
    string(16) "test-net-9122"
    ["name"]=>
    string(11) "test.net"
    ["ftpLogin"]=>
    string(7) "test"
    ["ftpPassword"]=>
    string(16) "qqqqqqqqqqqqqqqq"
    ["mysqlLogin"]=>
    string(7) "nexylan"
    ["mysqlPassword"]=>
    string(16) "qqqqqqqqqqqqqqqq"
    ["path"]=>
    string(20) "/var/www/test.net"
    ["subpath"]=>
    string(6) "htdocs"
    ["addedAt"]=>
    object(DateTime)#878 (3) {
      ["date"]=>
      string(19) "2012-10-11 17:32:00"
      ["timezone_type"]=>
      int(3)
      ["timezone"]=>
      string(12) "Europe/Paris"
    }
    ["status"]=>
    int(2)
    ["server"]=>
    &array(23) {
        [...]
    }
    ["ip"]=>
    &array(7) {
        [...]
    }
  }
}
```

After the double `current` calling in the else of the condition, the first field `id` is return, and the pager thinks it has 9122 items... :)

If i change the condition to count array which have only one items, it works perfectly !

Moreover, can you explain me the interest of this condition ? A simple `count()` of the result is not enough ?

I hope you can accept this PR rapidly and push a new version to fix that, I use you pager for a production of a project...

Thanks.
