### PR TITLE
Fix tests, QuerySubscriber

### DIFF
--- a/bin/vendors.php
+++ b/bin/vendors.php
@@ -14,9 +14,9 @@ $deps = array(
     array('Symfony/Component/EventDispatcher', 'http://github.com/symfony/EventDispatcher.git', 'v2.0.10'),
 
     // doctrine 2.3.x
-    array('doctrine-orm', 'http://github.com/doctrine/doctrine2.git', '6cd82d77f5'),
-    array('doctrine-dbal', 'http://github.com/doctrine/dbal.git', 'c8835edf74'),
-    array('doctrine-common', 'http://github.com/doctrine/common.git', 'fc26d10d97'),
+    array('doctrine-orm', 'http://github.com/doctrine/doctrine2.git', '304acf0a1a'),
+    array('doctrine-dbal', 'http://github.com/doctrine/dbal.git', 'fd45c6f6ba'),
+    array('doctrine-common', 'http://github.com/doctrine/common.git', 'bb0aebbf23'),
     array('doctrine-mongodb', 'http://github.com/doctrine/mongodb.git', 'd7fdcff25b'),
     array('doctrine-mongodb-odm', 'http://github.com/doctrine/mongodb-odm.git', 'e8c0bfb975'),
 

--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/ORM/Query/AsIsHydrator.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/ORM/Query/AsIsHydrator.php
@@ -1,0 +1,21 @@
+<?php
+namespace Knp\Component\Pager\Event\Subscriber\Paginate\Doctrine\ORM\Query;
+
+use Doctrine\ORM\Internal\Hydration\AbstractHydrator;
+
+
+/**
+ * As is hydrator to fetch count query result without resultSetMappings etc.
+ *
+ * @author Vladimir Chub <v@chub.com.ua>
+ */
+class AsIsHydrator extends AbstractHydrator
+{
+    /**
+     * Hydrates all rows from the current statement instance at once.
+     */
+    protected function hydrateAllData()
+    {
+        return $this->_stmt->fetchAll(\PDO::FETCH_ASSOC);
+    }
+}

--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/ORM/QuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/ORM/QuerySubscriber.php
@@ -63,23 +63,11 @@ class QuerySubscriber implements EventSubscriberInterface
                     ->setMaxResults(null)
                 ;
 
-                $conn = $countQuery->getEntityManager()->getConnection();
-                $params = $countQuery->getParameters()->toArray();
+                $countQuery->getEntityManager()->getConfiguration()->addCustomHydrationMode('asIs',
+                            'Knp\Component\Pager\Event\Subscriber\Paginate\Doctrine\ORM\Query\AsIsHydrator');
+                $countResult = $countQuery->getResult('asIs');
 
-                list($types, $params) = array_reduce($params, function ($res, Parameter $par) {
-                    $res[0][] = $par->getType();
-                    $res[1][] = $par->getValue();
-
-                    return $res;
-                }, array(array(), array()));
-
-                $countResult = $conn
-                    ->executeQuery($countQuery->getSQL(),
-                        $params,
-                        $types)
-                    ->fetchColumn();
-
-                $event->count = intval($countResult);
+                $event->count = intval(current(current($countResult)));
             }
             // process items
             $result = null;

--- a/tests/Test/Tool/BaseTestCaseORM.php
+++ b/tests/Test/Tool/BaseTestCaseORM.php
@@ -3,6 +3,8 @@
 namespace Test\Tool;
 
 use Doctrine\Common\Annotations\AnnotationReader;
+use Doctrine\ORM\Mapping\DefaultNamingStrategy;
+use Doctrine\ORM\Mapping\DefaultQuoteStrategy;
 use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\EntityManager;
 use Doctrine\Common\EventManager;
@@ -231,6 +233,24 @@ abstract class BaseTestCaseORM extends \PHPUnit_Framework_TestCase
             ->expects($this->any())
             ->method('getDefaultRepositoryClassName')
             ->will($this->returnValue('Doctrine\\ORM\\EntityRepository'))
+        ;
+
+        $config
+            ->expects($this->any())
+            ->method('getQuoteStrategy')
+            ->will($this->returnValue(new DefaultQuoteStrategy()))
+        ;
+
+        $config
+            ->expects($this->any())
+            ->method('getNamingStrategy')
+            ->will($this->returnValue(new DefaultNamingStrategy()))
+        ;
+
+        $config
+            ->expects($this->any())
+            ->method('getCustomHydrationMode')
+            ->will($this->returnValue('Knp\Component\Pager\Event\Subscriber\Paginate\Doctrine\ORM\Query\AsIsHydrator'))
         ;
 
         return $config;


### PR DESCRIPTION
- Fixed vendor.php (used actual 2.3), because old versions has some
  WhereInWalker BC breaks
- Updated doctrine -> updated BaseTestCaseORM for properly Configuration
  mocking
- Added AsIsHydrator for getting results in QuerySubscriber
- ORM tests mostly passed
  (shouldNotBeAbleToCountCompositeKeyOnByCountQueryWalker failed)

So i hope it will fix:
- https://github.com/KnpLabs/knp-components/issues/53
- https://github.com/KnpLabs/KnpPaginatorBundle/issues/155
- https://github.com/KnpLabs/KnpPaginatorBundle/issues/154
