### PR TITLE
[bugfix] Doctrine needs to process parameters otherwise they will enter the query improperly

### DIFF
--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/ORM/QuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/ORM/QuerySubscriber.php
@@ -66,16 +66,16 @@ class QuerySubscriber implements EventSubscriberInterface
                 $conn = $countQuery->getEntityManager()->getConnection();
                 $params = $countQuery->getParameters()->toArray();
 
-                list($types, $params) = array_reduce($params, function ($res, Parameter $par) {
-                    $res[0][] = $par->getType();
-                    $res[1][] = $par->getValue();
-
-                    return $res;
-                }, array(array(), array()));
+                $processedParams = array();
+                $types = array();
+                foreach( $params as $key => $param ) {
+                    $processedParams[ $key ] = $countQuery->processParameterValue( $param->getValue() );
+                    $types[ $key ] = $param->getType();
+                }
 
                 $countResult = $conn
                     ->executeQuery($countQuery->getSQL(),
-                        $params,
+                        $processedParams,
                         $types)
                     ->fetchColumn();
 


### PR DESCRIPTION
The bugfix made by ChubV (https://github.com/KnpLabs/knp-components/pull/51) introduced a problem where certain parameters were no longer processed properly, causing them to enter the final query as their classname instead of being translated into an ID.

I have made a small change so that each parameter is first processed by Doctrine to make sure the proper value is selected for the query.
