### PR TITLE
Backwards compatinbility to Symfony 2.0

### DIFF
--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/ORM/Query/AsIsHydrator.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/ORM/Query/AsIsHydrator.php
@@ -18,4 +18,12 @@ class AsIsHydrator extends AbstractHydrator
     {
         return $this->_stmt->fetchAll(\PDO::FETCH_ASSOC);
     }
+    
+    /**
+     * Added to provide backwards compatibility 
+     */
+    protected function _hydrateAll ()
+    {
+        return $this->hydrateAllData();
+    }
 }


### PR DESCRIPTION
Added method used in older versions of Doctrine to provide compatibility to the version used in Symfony 2.0.