### PR TITLE
Callback subscriber

### DIFF
--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/Callback/CallbackSubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/Callback/CallbackSubscriber.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Knp\Component\Pager\Event\Subscriber\Paginate\Callback;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Knp\Component\Pager\Event\ItemsEvent;
+
+class CallbackSubscriber implements EventSubscriberInterface
+{
+    public function items(ItemsEvent $event)
+    {
+        if ($event->target instanceof Target) {
+            $event->count = $event->target->count();
+            $event->items = $event->target->items(
+                $event->getOffset(),
+                $event->getLimit()
+            );
+            $event->stopPropagation();
+        }
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            'knp_pager.items' => array('items', 0)
+        );
+    }
+}

--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/Callback/Target.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/Callback/Target.php
@@ -19,12 +19,12 @@ class Target {
 
     public function count()
     {
-        return call_user_func_array($this->countCallback, []);
+        return call_user_func_array($this->countCallback, array());
     }
 
     public function items($limit, $offset)
     {
-        return call_user_func_array($this->itemCallback, [$limit, $offset]);
+        return call_user_func_array($this->itemCallback, array($limit, $offset));
     }
 
 }

--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/Callback/Target.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/Callback/Target.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Knp\Component\Pager\Event\Subscriber\Paginate\Callback;
+
+
+class Target {
+
+    protected $countCallback;
+    protected $itemCallback;
+
+    public function __construct($countCallback, $itemCallback)
+    {
+        if (!is_callable($countCallback)) throw new \InvalidArgumentException("'count' argument is not callable");
+        if (!is_callable($itemCallback)) throw new \InvalidArgumentException("'itemCallback' argument is not callable");
+
+        $this->countCallback = $countCallback;
+        $this->itemCallback = $itemCallback;
+    }
+
+    public function count()
+    {
+        return call_user_func_array($this->countCallback, []);
+    }
+
+    public function items($limit, $offset)
+    {
+        return call_user_func_array($this->itemCallback, [$limit, $offset]);
+    }
+
+}

--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/PaginationSubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/PaginationSubscriber.php
@@ -29,6 +29,7 @@ class PaginationSubscriber implements EventSubscriberInterface
         $disp->addSubscriber(new PropelQuerySubscriber);
         $disp->addSubscriber(new SolariumQuerySubscriber());
         $disp->addSubscriber(new ElasticaQuerySubscriber());
+        $disp->addSubscriber(new Callback\CallbackSubscriber());
     }
 
     public static function getSubscribedEvents()

--- a/tests/Test/Pager/Subscriber/Paginate/CallbackTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/CallbackTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use Test\Tool\BaseTestCase;
+use Knp\Component\Pager\Paginator;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Test\Mock\PaginationSubscriber as MockPaginationSubscriber;
+use Knp\Component\Pager\Event\Subscriber\Paginate\Callback\Target;
+use Knp\Component\Pager\Event\Subscriber\Paginate\Callback\CallbackSubscriber;
+
+class CallbackTest extends BaseTestCase {
+
+    /**
+     * @test
+     */
+    function shouldPaginateCallbackTarget()
+    {
+        $dispatcher = new EventDispatcher;
+        $dispatcher->addSubscriber(new CallbackSubscriber);
+        $dispatcher->addSubscriber(new MockPaginationSubscriber); // pagination view
+        $p = new Paginator($dispatcher);
+
+        $items = array('item1', 'item2', 'item3');
+        $target = new Target(function() use ($items) {
+            return count($items);
+        }, function($limit, $offset) use ($items) {
+            return array_splice($items, $offset, $limit);
+        });
+
+        $view = $p->paginate($target, 2, 1);
+
+        $this->assertEquals(2, $view->getCurrentPageNumber());
+        $this->assertEquals(1, $view->getItemNumberPerPage());
+        $this->assertEquals(1, count($view->getItems()));
+        $this->assertEquals(3, $view->getTotalItemCount());
+        $this->assertEquals(array('item2'), $view->getItems());
+    }
+
+    /**
+     * @test
+     * @expectedException RuntimeException
+     */
+    function shouldIgnoreIncorrectTarget()
+    {
+        $dispatcher = new EventDispatcher;
+        $dispatcher->addSubscriber(new CallbackSubscriber);
+        $dispatcher->addSubscriber(new MockPaginationSubscriber); // pagination view
+        $p = new Paginator($dispatcher);
+
+        $items = array('item1', 'item2', 'item3');
+        $view = $p->paginate($items, 2, 1);
+    }
+
+}


### PR DESCRIPTION
Added ability to specify callback for pagination.

``` php
$pagination = $paginator->paginate(
    new PaginationCallback(function() use ($service) {
        return $service->total();
    }, function($limit, $offset) use ($service) {
        return $service->getAll($limit, $offset);
    }),
    $this->get('request')->query->get('page', 1), 1
);
```
