### PR TITLE
Fixed bug introduced in pull request #82 : All arrays are now filtered with Solarium

### DIFF
--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/SolariumQuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/SolariumQuerySubscriber.php
@@ -15,7 +15,9 @@ class SolariumQuerySubscriber implements EventSubscriberInterface
     public function items(ItemsEvent $event)
     {
         if (is_array($event->target) && 2 == count($event->target)) {
-            list($client, $query) = $event->target;
+            $values = array_values($event->target);
+            list($client, $query) = $values;
+
             if ($client instanceof \Solarium\Client && $query instanceof \Solarium\QueryType\Select\Query\Query) {
                 $query->setStart($event->getOffset())->setRows($event->getLimit());
                 $solrResult = $client->select($query);

--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/SolariumQuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/SolariumQuerySubscriber.php
@@ -15,7 +15,9 @@ class SolariumQuerySubscriber implements EventSubscriberInterface
     public function items(ItemsEvent $event)
     {
         if (is_array($event->target) && 2 == count($event->target)) {
-            list($client, $query) = $event->target;
+            $values = array_values($event->target);
+            list($client, $query) = $values;
+
             if ($client instanceof \Solarium\Client && $query instanceof \Solarium\QueryType\Select\Query\Query) {
                 if (isset($_GET[$event->options['sortFieldParameterName']])) {
                     if (isset($event->options['sortFieldWhitelist'])) {

--- a/tests/Test/Pager/Subscriber/Paginate/SolariumQuerySubscriberTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/SolariumQuerySubscriberTest.php
@@ -1,10 +1,13 @@
 <?php
 
+namespace Test\Pager\Subscriber\Paginate;
+
 use Knp\Component\Pager\Paginator;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Knp\Component\Pager\Pagination\PaginationInterface;
 use Knp\Component\Pager\Event\Subscriber\Paginate\ArraySubscriber;
 use Knp\Component\Pager\Event\Subscriber\Paginate\SolariumQuerySubscriber;
+
 use Test\Mock\PaginationSubscriber as MockPaginationSubscriber;
 
 class SolariumQuerySubscriberTest extends \PHPUnit_Framework_TestCase

--- a/tests/Test/Pager/Subscriber/Sortable/SolariumQuerySubscriberTest.php
+++ b/tests/Test/Pager/Subscriber/Sortable/SolariumQuerySubscriberTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Test\Pager\Subscriber\Sortable;
+
+use Knp\Component\Pager\Paginator;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Knp\Component\Pager\Pagination\PaginationInterface;
+use Knp\Component\Pager\Event\Subscriber\Sortable\SolariumQuerySubscriber;
+
+use Test\Mock\PaginationSubscriber as MockPaginationSubscriber;
+
+class SolariumQuerySubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @test
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage One of listeners must count and slice given target
+     */
+    function testArrayShouldNotBeHandled()
+    {
+        $array = array(
+            'results' => array(
+                0 => array(
+                    'city'   => 'Lyon',
+                    'market' => 'E'
+                ),
+                1 => array(
+                    'city'   => 'Paris',
+                    'market' => 'G'
+                ),
+            ),
+            'nbTotalResults' => 2
+        );
+
+        $dispatcher = new EventDispatcher;
+        $dispatcher->addSubscriber(new SolariumQuerySubscriber);
+        $dispatcher->addSubscriber(new MockPaginationSubscriber);
+
+        $p = new Paginator($dispatcher);
+        $p->paginate($array, 1, 10);
+    }
+}


### PR DESCRIPTION
The commit e31f1f57f4c4222f1a106ed81623c5b1e817b518 introduced a bug where an array will be automatically paginated/sorted using the `SolariumQuerySubscriber`

I don't know why travis said that the PR was good to merge because it made a unit test failed.

I've added another test against the `SolariumQuerySubscriber`
