### PR TITLE
Fix sets event dispatcher (Error exists after sf update)

### DIFF
--- a/src/Knp/Component/Pager/Paginator.php
+++ b/src/Knp/Component/Pager/Paginator.php
@@ -2,6 +2,7 @@
 
 namespace Knp\Component\Pager;
 
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Knp\Component\Pager\Event\Subscriber\Paginate\PaginationSubscriber;


### PR DESCRIPTION
SF Updated: use \Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher if use debug mode.
