### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
     ],
 
     "require": {
-        "php": ">=5.3.2"
+        "php": ">=5.3.2",
+        "symfony/event-dispatcher": "2.*"
     },
 
     "suggest": {


### PR DESCRIPTION
An explicit dependency on event dispatcher must be placed in composer, since it's used in Paginator.php (and in other classes)