### PR TITLE
Enhance performance for QueryBuilder subscriber

### DIFF
--- a/src/Knp/Component/Pager/Event/ItemsEvent.php
+++ b/src/Knp/Component/Pager/Event/ItemsEvent.php
@@ -17,6 +17,13 @@ class ItemsEvent extends Event
     public $target;
 
     /**
+     * An optional separated target for counting purpose
+     *
+     * @var mixed
+     */
+    public $countTarget;
+
+    /**
      * List of options
      *
      * @var array

--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/ORM/QueryBuilderSubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/ORM/QueryBuilderSubscriber.php
@@ -12,7 +12,14 @@ class QueryBuilderSubscriber implements EventSubscriberInterface
     {
         if ($event->target instanceof QueryBuilder) {
             // change target into query
-            $event->target = $event->target->getQuery();
+            $queryBuilder = $event->target;
+
+            // Remove "order by" part for the count query for performance purpose
+            $countQueryBuilder = clone $queryBuilder;
+            $countQueryBuilder->resetDQLPart('orderBy');
+
+            $event->target = $queryBuilder->getQuery();
+            $event->countTarget = $countQueryBuilder->getQuery();
         }
     }
 

--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/ORM/QuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/ORM/QuerySubscriber.php
@@ -36,7 +36,12 @@ class QuerySubscriber implements EventSubscriberInterface
             if (($count = $event->target->getHint(self::HINT_COUNT)) !== false) {
                 $event->count = intval($count);
             } else {
-                $countQuery = QueryHelper::cloneQuery($event->target);
+                if (isset($event->countTarget)) {
+                    $countQuery = $event->countTarget;
+                } else {
+                    $countQuery = QueryHelper::cloneQuery($event->target);
+                }
+                
                 if ($useDoctrineOutputWalker) {
                     $treeWalker = 'Doctrine\ORM\Tools\Pagination\CountOutputWalker';
                     $countQuery->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, $treeWalker);


### PR DESCRIPTION
This is a quick enhancement that removes the "order by" part of the query for counting total number of rows, which can lead to huge performance improvements for some queries.

Unfortunately this only works for the query builder subscriber as it is not easy to remove the "order by" part for a query.

This is my first PR on this project, so if you prefer that I do it in a different way, feel free to ask me to!

I didn't add any unit test on this as this is not a new feature.
