### PR TITLE
Clone the parameters too since they are an object

### DIFF
--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/ORM/Query/Helper.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/ORM/Query/Helper.php
@@ -20,7 +20,7 @@ class Helper
     public static function cloneQuery(Query $query)
     {
         $clonedQuery = clone $query;
-        $clonedQuery->setParameters($query->getParameters());
+        $clonedQuery->setParameters(clone $query->getParameters());
         // attach hints
         foreach ($query->getHints() as $name => $hint) {
             $clonedQuery->setHint($name, $hint);


### PR DESCRIPTION
We need to clone the parameters for this query or the parameters could change if the original query's parameters are changed.
This is how doctrine does it. 
https://github.com/doctrine/doctrine2/blob/master/lib/Doctrine/ORM/Tools/Pagination/Paginator.php#L212
To bad that method isn't static.
