### PR TITLE
Update ElasticaQuerySubscribers to use SearchableInterface and Query

### DIFF
--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/ElasticaQuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/ElasticaQuerySubscriber.php
@@ -2,6 +2,8 @@
 
 namespace Knp\Component\Pager\Event\Subscriber\Paginate;
 
+use Elastica\Query;
+use Elastica\SearchableInterface;
 use Knp\Component\Pager\Event\ItemsEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -13,7 +15,7 @@ class ElasticaQuerySubscriber implements EventSubscriberInterface
 {
     public function items(ItemsEvent $event)
     {
-        if (is_array($event->target) && 2 === count($event->target) && reset($event->target) instanceof \Elastica_Searchable && end($event->target) instanceof \Elastica_Query) {
+        if (is_array($event->target) && 2 === count($event->target) && reset($event->target) instanceof SearchableInterface && end($event->target) instanceof Query) {
             list($searchable, $query) = $event->target;
 
             $query->setFrom($event->getOffset());
@@ -21,7 +23,10 @@ class ElasticaQuerySubscriber implements EventSubscriberInterface
             $results = $searchable->search($query);
 
             $event->count = $results->getTotalHits();
-            if ($results->hasFacets()) {
+            //Faceting is being replaced by aggregations
+            if ($results->hasAggregations()) {
+                $event->setCustomPaginationParameter('aggregations', $results->getAggregations());
+            } elseif ($results->hasFacets()) {
                 $event->setCustomPaginationParameter('facets', $results->getFacets());
             }
             $event->items = $results->getResults();

--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/ElasticaQuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/ElasticaQuerySubscriber.php
@@ -4,12 +4,14 @@ namespace Knp\Component\Pager\Event\Subscriber\Sortable;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Knp\Component\Pager\Event\ItemsEvent;
+use Elastica\Query;
+use Elastica\SearchableInterface;
 
 class ElasticaQuerySubscriber implements EventSubscriberInterface
 {
     public function items(ItemsEvent $event)
     {
-        if (is_array($event->target) && 2 === count($event->target) && reset($event->target) instanceof \Elastica_Searchable && end($event->target) instanceof \Elastica_Query) {
+        if (is_array($event->target) && 2 === count($event->target) && reset($event->target) instanceof SearchableInterface && end($event->target) instanceof Query) {
             list($searchable, $query) = $event->target;
 
             if (isset($_GET[$event->options['sortFieldParameterName']])) {


### PR DESCRIPTION
Fixing issue as mentioned in #109 - ElasticaQuerySubscribers now use the `Elastica\SearchableInterface` and `Elastica\Query` classes, instead of the old `Elastica_Searchable` and `Elastica_Query` in the `if` of the subscriber itself. 

Also, simply added a check to see if the result set has Aggregation - in addition to `hasFacets` I added `hasAggregations` and if true, simply add the aggregations on as a special parameter. 
