### PR TITLE
Quick and dirty patch to avoid the use of Doctrine\ORM\Tools\Pagination\...

### DIFF
--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/ORM/QuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/ORM/QuerySubscriber.php
@@ -37,7 +37,7 @@ class QuerySubscriber implements EventSubscriberInterface
                 $event->count = intval($count);
             } else {
                 $countQuery = QueryHelper::cloneQuery($event->target);
-                if ($useDoctrineOutputWalker) {
+                if ($useDoctrineOutputWalker AND null !== $countQuery->getAST()->havingClause) {
                     $treeWalker = 'Doctrine\ORM\Tools\Pagination\CountOutputWalker';
                     $countQuery->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, $treeWalker);
                 } else if ($useDoctrineWalkers) {


### PR DESCRIPTION
Quick and dirty patch to avoid the use of Doctrine\ORM\Tools\Pagination\CountOutputWalker when the query to count does not contains a HAVING clause. Instead the Doctrine\ORM\Tools\Pagination\CountWalker is used and produce a better query for performance.
