### PR TITLE
Update the CompositeKeyTest to use a populated schema.

### DIFF
--- a/tests/Test/Pager/Subscriber/Paginate/Doctrine/ORM/CompositeKeyTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/Doctrine/ORM/CompositeKeyTest.php
@@ -17,6 +17,7 @@ class CompositeKeyTest extends BaseTestCaseORM
     {
         $p = new Paginator;
         $em = $this->getMockSqliteEntityManager();
+        $this->populate($em);
 
         $count = $em
             ->createQuery('SELECT COUNT(c) FROM Test\Fixture\Entity\Composite c')
@@ -27,15 +28,45 @@ class CompositeKeyTest extends BaseTestCaseORM
             ->createQuery('SELECT c FROM Test\Fixture\Entity\Composite c')
             ->setHint('knp_paginator.count', $count)
         ;
-        $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, false);
+        $query->setHint(UsesPaginator::HINT_FETCH_JOIN_COLLECTION, false);
         $view = $p->paginate($query, 1, 10, array('wrap-queries' => true));
 
         $items = $view->getItems();
-        $this->assertEquals(0, count($items));
+        $this->assertEquals(4, count($items));
     }
 
     protected function getUsedEntityFixtures()
     {
         return array('Test\Fixture\Entity\Composite');
     }
+
+    private function populate($em)
+    {
+        $summer = new Composite;
+        $summer->setId(1);
+        $summer->setTitle('summer');
+        $summer->setUid(100);
+
+        $winter = new Composite;
+        $winter->setId(2);
+        $winter->setTitle('winter');
+        $winter->setUid(200);
+
+        $autumn = new Composite;
+        $autumn->setId(3);
+        $autumn->setTitle('autumn');
+        $autumn->setUid(300);
+
+        $spring = new Composite;
+        $spring->setId(4);
+        $spring->setTitle('spring');
+        $spring->setUid(400);
+
+        $em->persist($summer);
+        $em->persist($winter);
+        $em->persist($autumn);
+        $em->persist($spring);
+        $em->flush();
+    }
+
 }


### PR DESCRIPTION
I was facing a bug while paginating a Doctrine entity that had a composite primary key and getting this exception:

    Single id is not allowed on composite primary key in entity [...]

After poking in the code, I actually found that the exception was being thrown by Doctrine, and there was already a test for that. To my amusement, the test was passing. I tried to do in my code exactly what the test was doing, but no dice.

So I poked a little bit more and discovered that the CompositeKeyTest was running with an empty schema, and that's why it succeded and my code didn't. It took me to just populate the testing schema with some fixtures for the test to fail just like my code.

After a while, I was able to make it work using some crazy hint which I am not sure if it works generally, but worked for me.

Can you guys help to check if those changes make sense at all?

Thanks!