### PR TITLE
Implemented sorting by multiple fields for paginator (only ORM)

### DIFF
--- a/doc/pager/config.md
+++ b/doc/pager/config.md
@@ -9,33 +9,39 @@ For example, Doctrine ORM subscriber will generate different sql queries if the 
 
 The list of existing options are:
 
-| name                       | type   | default value | subscribers                                     |
-| -------------------------- | ------ | ------------- | ----------------------------------------------- |
-| wrap-queries               | bool   | false         | orm QuerySubscriber, orm QueryBuilderSubscriber |
-| distinct                   | bool   | true          | QuerySubscriber, QueryBuilderSubscriber         |
-| pageParameterName          | string | page          | SortableSubscriber                              |
-| defaultSortFieldName       | string |               | SortableSubscriber                              |
-| defaultSortDirection       | string | asc           | SortableSubscriber                              |
-| sortFieldWhitelist         | array  | []            | SortableSubscriber                              |
-| sortFieldParameterName     | string | sort          | SortableSubscriber                              |
-| sortDirectionParameterName | string | sort          | SortableSubscriber                              |
-| filterFieldParameterName   | string | filterParam   | FiltrationSubscriber                            |
-| filterValueParameterName   | string | filterValue   | FiltrationSubscriber                            |
+| name                       | type           | default value | subscribers                                     |
+| -------------------------- | -------------- | ------------- | ----------------------------------------------- |
+| wrap-queries               | bool           | false         | orm QuerySubscriber, orm QueryBuilderSubscriber |
+| distinct                   | bool           | true          | QuerySubscriber, QueryBuilderSubscriber         |
+| pageParameterName          | string         | page          | SortableSubscriber                              |
+| defaultSortFieldName       | string\|array* |               | SortableSubscriber                              |
+| defaultSortDirection       | string         | asc           | SortableSubscriber                              |
+| sortFieldWhitelist         | array          | []            | SortableSubscriber                              |
+| sortFieldParameterName     | string         | sort          | SortableSubscriber                              |
+| sortDirectionParameterName | string         | sort          | SortableSubscriber                              |
+| filterFieldParameterName   | string         | filterParam   | FiltrationSubscriber                            |
+| filterValueParameterName   | string         | filterValue   | FiltrationSubscriber                            |
 
 
 ## Noticeable behaviors of some options
 
-### `distinct` 
+### `distinct`
 
 If set to true, will add a distinct sql keyword on orm queries to ensuire unicity of counted results
 
 
-### `wrap-queries` 
+### `wrap-queries`
 
-If set to true, will take advantage of doctrine 2.3 output walkers by using subqueries to handle composite keys and HAVING queries.  
+If set to true, will take advantage of doctrine 2.3 output walkers by using subqueries to handle composite keys and HAVING queries.
 This can considerably impact performances depending on the query and the platform, you will have to consider it at some point.
 
 If you want to order your results by a column from a fetch joined t-many association,
 you have to set `wrap-queries` to `true`. Otherwise you will get an exception with this warning:
 *"Cannot select distinct identifiers from query with LIMIT and ORDER BY on a column from a fetch joined to-many association. Use output walkers."*
 
+
+### `defaultSortFieldName`
+
+Used as default field name for the sorting. It can take an array for sorting by multiple fields.
+
+\* **Attention**: Arrays are only supported for *Doctrine's ORM*.

--- a/doc/pager/usage.md
+++ b/doc/pager/usage.md
@@ -78,3 +78,20 @@ $pagination->renderer = function($data) {
 };
 echo $pagination; // outputs: "page range: 1 2 3"
 ```
+
+## Sorting database query results by multiple columns (only Doctrine ORM)
+
+It is not uncommonly that the result of a database query should be sorted by multiple columns.
+For example users should be sorted by lastname and by firstname:
+
+```php
+$query = $entityManager->createQuery('SELECT u FROM User');
+
+$pagination = $paginator->paginate($query, 1/*page number*/, 20/*limit per page*/, array(
+    'defaultSortFieldName' => array('u.lastname', 'u.firstname'),
+    'defaultSortDirection' => 'asc',
+));
+```
+
+The Paginator will add an `ORDER BY` automatically for each attribute for the
+`defaultSortFieldName` option.

--- a/src/Knp/Component/Pager/Paginator.php
+++ b/src/Knp/Component/Pager/Paginator.php
@@ -88,6 +88,11 @@ class Paginator implements PaginatorInterface
         }
         $offset = abs($page - 1) * $limit;
         $options = array_merge($this->defaultOptions, $options);
+
+        // normalize default sort field
+        if (isset($options['defaultSortFieldName']) && is_array($options['defaultSortFieldName'])) {
+            $options['defaultSortFieldName'] = implode('+', $options['defaultSortFieldName']);
+        }
         
         // default sort field and direction are set based on options (if available)
         if (!isset($_GET[$options['sortFieldParameterName']]) && isset($options['defaultSortFieldName'])) {

--- a/tests/Test/Pager/Subscriber/Sortable/Doctrine/ORM/QueryTest.php
+++ b/tests/Test/Pager/Subscriber/Sortable/Doctrine/ORM/QueryTest.php
@@ -95,8 +95,8 @@ class QueryTest extends BaseTestCaseORM
 
         $this->assertEquals(4, $this->queryAnalyzer->getNumExecutedQueries());
         $executed = $this->queryAnalyzer->getExecutedQueries();
-        $this->assertEquals('SELECT a0_.id AS id0, a0_.title AS title1 FROM Article a0_ ORDER BY a0_.title ASC LIMIT 10 OFFSET 0', $executed[1]);
-        $this->assertEquals('SELECT a0_.id AS id0, a0_.title AS title1 FROM Article a0_ ORDER BY a0_.title DESC LIMIT 10 OFFSET 0', $executed[3]);
+        $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1 FROM Article a0_ ORDER BY a0_.title ASC LIMIT 10 OFFSET 0', $executed[1]);
+        $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1 FROM Article a0_ ORDER BY a0_.title DESC LIMIT 10 OFFSET 0', $executed[3]);
     }
 
     /**
@@ -139,7 +139,7 @@ ___SQL;
 
         $this->assertEquals(2, $this->queryAnalyzer->getNumExecutedQueries());
         $executed = $this->queryAnalyzer->getExecutedQueries();
-        $this->assertEquals('SELECT a0_.id AS id0, a0_.title AS title1, COUNT(a0_.id) AS sclr2 FROM Article a0_ ORDER BY sclr2 ASC LIMIT 10 OFFSET 0', $executed[1]);
+        $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1, COUNT(a0_.id) AS sclr_2 FROM Article a0_ ORDER BY sclr_2 ASC LIMIT 10 OFFSET 0', $executed[1]);
     }
 
     /**
@@ -164,7 +164,7 @@ ___SQL;
 
         $this->assertEquals(2, $this->queryAnalyzer->getNumExecutedQueries());
         $executed = $this->queryAnalyzer->getExecutedQueries();
-        $this->assertEquals('SELECT a0_.id AS id0, a0_.title AS title1 FROM Article a0_ ORDER BY a0_.title ASC LIMIT 10 OFFSET 0', $executed[1]);
+        $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1 FROM Article a0_ ORDER BY a0_.title ASC LIMIT 10 OFFSET 0', $executed[1]);
     }
 
     /**

--- a/tests/Test/Pager/Subscriber/Sortable/Doctrine/ORM/QueryTest.php
+++ b/tests/Test/Pager/Subscriber/Sortable/Doctrine/ORM/QueryTest.php
@@ -96,7 +96,7 @@ class QueryTest extends BaseTestCaseORM
         $this->assertEquals(4, $this->queryAnalyzer->getNumExecutedQueries());
         $executed = $this->queryAnalyzer->getExecutedQueries();
 
-        // Different aliases separators according to Doctrine version (according to PHP version)
+        // Different aliases separators according to Doctrine version
         if (version_compare(\Doctrine\ORM\Version::VERSION, '2.5', '<')) {
             $this->assertEquals('SELECT a0_.id AS id0, a0_.title AS title1 FROM Article a0_ ORDER BY a0_.title ASC LIMIT 10 OFFSET 0', $executed[1]);
             $this->assertEquals('SELECT a0_.id AS id0, a0_.title AS title1 FROM Article a0_ ORDER BY a0_.title DESC LIMIT 10 OFFSET 0', $executed[3]);
@@ -147,7 +147,7 @@ ___SQL;
         $this->assertEquals(2, $this->queryAnalyzer->getNumExecutedQueries());
         $executed = $this->queryAnalyzer->getExecutedQueries();
 
-        // Different aliases separators according to Doctrine version (according to PHP version)
+        // Different aliases separators according to Doctrine version
         if (version_compare(\Doctrine\ORM\Version::VERSION, '2.5', '<')) {
             $this->assertEquals('SELECT a0_.id AS id0, a0_.title AS title1, COUNT(a0_.id) AS sclr2 FROM Article a0_ ORDER BY sclr2 ASC LIMIT 10 OFFSET 0', $executed[1]);
         } else {
@@ -178,7 +178,7 @@ ___SQL;
         $this->assertEquals(2, $this->queryAnalyzer->getNumExecutedQueries());
         $executed = $this->queryAnalyzer->getExecutedQueries();
 
-        // Different aliases separators according to Doctrine version (according to PHP version)
+        // Different aliases separators according to Doctrine version
         if (version_compare(\Doctrine\ORM\Version::VERSION, '2.5', '<')) {
             $this->assertEquals('SELECT a0_.id AS id0, a0_.title AS title1 FROM Article a0_ ORDER BY a0_.title ASC LIMIT 10 OFFSET 0', $executed[1]);
         } else {

--- a/tests/Test/Pager/Subscriber/Sortable/Doctrine/ORM/QueryTest.php
+++ b/tests/Test/Pager/Subscriber/Sortable/Doctrine/ORM/QueryTest.php
@@ -95,8 +95,15 @@ class QueryTest extends BaseTestCaseORM
 
         $this->assertEquals(4, $this->queryAnalyzer->getNumExecutedQueries());
         $executed = $this->queryAnalyzer->getExecutedQueries();
-        $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1 FROM Article a0_ ORDER BY a0_.title ASC LIMIT 10 OFFSET 0', $executed[1]);
-        $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1 FROM Article a0_ ORDER BY a0_.title DESC LIMIT 10 OFFSET 0', $executed[3]);
+
+        // Different aliases separators according to Doctrine version (according to PHP version)
+        if (version_compare(\Doctrine\ORM\Version::VERSION, '2.5', '<')) {
+            $this->assertEquals('SELECT a0_.id AS id0, a0_.title AS title1 FROM Article a0_ ORDER BY a0_.title ASC LIMIT 10 OFFSET 0', $executed[1]);
+            $this->assertEquals('SELECT a0_.id AS id0, a0_.title AS title1 FROM Article a0_ ORDER BY a0_.title DESC LIMIT 10 OFFSET 0', $executed[3]);
+        } else {
+            $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1 FROM Article a0_ ORDER BY a0_.title ASC LIMIT 10 OFFSET 0', $executed[1]);
+            $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1 FROM Article a0_ ORDER BY a0_.title DESC LIMIT 10 OFFSET 0', $executed[3]);
+        }
     }
 
     /**
@@ -139,7 +146,13 @@ ___SQL;
 
         $this->assertEquals(2, $this->queryAnalyzer->getNumExecutedQueries());
         $executed = $this->queryAnalyzer->getExecutedQueries();
-        $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1, COUNT(a0_.id) AS sclr_2 FROM Article a0_ ORDER BY sclr_2 ASC LIMIT 10 OFFSET 0', $executed[1]);
+
+        // Different aliases separators according to Doctrine version (according to PHP version)
+        if (version_compare(\Doctrine\ORM\Version::VERSION, '2.5', '<')) {
+            $this->assertEquals('SELECT a0_.id AS id0, a0_.title AS title1, COUNT(a0_.id) AS sclr2 FROM Article a0_ ORDER BY sclr2 ASC LIMIT 10 OFFSET 0', $executed[1]);
+        } else {
+            $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1, COUNT(a0_.id) AS sclr_2 FROM Article a0_ ORDER BY sclr_2 ASC LIMIT 10 OFFSET 0', $executed[1]);
+        }
     }
 
     /**
@@ -164,7 +177,13 @@ ___SQL;
 
         $this->assertEquals(2, $this->queryAnalyzer->getNumExecutedQueries());
         $executed = $this->queryAnalyzer->getExecutedQueries();
-        $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1 FROM Article a0_ ORDER BY a0_.title ASC LIMIT 10 OFFSET 0', $executed[1]);
+
+        // Different aliases separators according to Doctrine version (according to PHP version)
+        if (version_compare(\Doctrine\ORM\Version::VERSION, '2.5', '<')) {
+            $this->assertEquals('SELECT a0_.id AS id0, a0_.title AS title1 FROM Article a0_ ORDER BY a0_.title ASC LIMIT 10 OFFSET 0', $executed[1]);
+        } else {
+            $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1 FROM Article a0_ ORDER BY a0_.title ASC LIMIT 10 OFFSET 0', $executed[1]);
+        }
     }
 
     /**

--- a/tests/Test/Tool/BaseTestCaseORM.php
+++ b/tests/Test/Tool/BaseTestCaseORM.php
@@ -253,6 +253,12 @@ abstract class BaseTestCaseORM extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue('Knp\Component\Pager\Event\Subscriber\Paginate\Doctrine\ORM\Query\AsIsHydrator'))
         ;
 
+        $config
+            ->expects($this->any())
+            ->method('getDefaultQueryHints')
+            ->will($this->returnValue(array()))
+        ;
+
         return $config;
     }
 }


### PR DESCRIPTION
In one of my projects I need sorting by multiple fields and it is requested by  others (see KnpLabs/KnpPaginatorBundle#255), too. So I have extended the Paginator, QuerySubscriber and the OrderByWalker.

I have chosen an implementation which is not the nicest, but it keeps backward compatiblity. All tests are passing.

Example how to use this feature:
```php
        $pagination = $paginator->paginate(
            $queryBuilder,
            $page,
            $pageSize,
            array(
                'defaultSortFieldName' => ['user.lastname', 'user.firstname'],
                'defaultSortDirection' => 'asc'
            )
        );
```
I can only provide a solution for Doctrine's ORM. I hope this is no problem.