### PR TITLE
- Add event subscriber to allow array to be sortable

### DIFF
--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/ArraySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/ArraySubscriber.php
@@ -24,8 +24,7 @@ class ArraySubscriber implements EventSubscriberInterface
     {
         if (is_array($event->target) && count($event->target) > 1)
         {
-            if (isset($_GET[$event->options['sortFieldParameterName']]))
-            {
+            if (isset($_GET[$event->options['sortFieldParameterName']])) {
                 $this->sortDirection = isset($_GET[$event->options['sortDirectionParameterName']]) && strtolower($_GET[$event->options['sortDirectionParameterName']]) === 'asc' ? 'asc' : 'desc';
 
                 // TODO add whitelist
@@ -36,8 +35,7 @@ class ArraySubscriber implements EventSubscriberInterface
 //                }
 
                 $sortFieldParameterName = explode('.', $_GET[$event->options['sortFieldParameterName']]);
-                if(isset($sortFieldParameterName[1]))
-                {
+                if(isset($sortFieldParameterName[1])) {
                     // Capitalize first letter in order to prepare getter construction
                     $sortFieldName = ucfirst($sortFieldParameterName[1]);
 
@@ -45,8 +43,7 @@ class ArraySubscriber implements EventSubscriberInterface
 
                     // Getter detection
                     $class = new ReflectionClass(get_class($event->target[0]));
-                    if($class->hasMethod($this->currentSortingFieldGetter))
-                    {
+                    if($class->hasMethod($this->currentSortingFieldGetter)) {
                         // Sort
                         usort($event->target, array($this, "sort" . ucfirst($this->sortDirection)));
                     }

--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/ArraySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/ArraySubscriber.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Knp\Component\Pager\Event\Subscriber\Sortable;
+
+use \ReflectionClass;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Knp\Component\Pager\Event\ItemsEvent;
+use Doctrine\ORM\Query;
+
+class ArraySubscriber implements EventSubscriberInterface
+{
+
+    /**
+     * @var string the field used to sort current object array list
+     */
+    private $currentSortingFieldGetter;
+
+    /**
+     * @var string the sorting direction
+     */
+    private $sortDirection;
+
+    public function items(ItemsEvent $event)
+    {
+        if (is_array($event->target) && count($event->target) > 1)
+        {
+            if (isset($_GET[$event->options['sortFieldParameterName']]))
+            {
+                $this->sortDirection = isset($_GET[$event->options['sortDirectionParameterName']]) && strtolower($_GET[$event->options['sortDirectionParameterName']]) === 'asc' ? 'asc' : 'desc';
+
+                // TODO add whitelist
+//                if (isset($event->options['sortFieldWhitelist'])) {
+//                    if (!in_array($_GET[$event->options['sortFieldParameterName']], $event->options['sortFieldWhitelist'])) {
+//                        throw new \UnexpectedValueException("Cannot sort by: [{$_GET[$event->options['sortFieldParameterName']]}] this field is not in whitelist");
+//                    }
+//                }
+
+                $sortFieldParameterName = explode('.', $_GET[$event->options['sortFieldParameterName']]);
+                if(isset($sortFieldParameterName[1]))
+                {
+                    // Capitalize first letter in order to prepare getter construction
+                    $sortFieldName = ucfirst($sortFieldParameterName[1]);
+
+                    $this->currentSortingFieldGetter = "get{$sortFieldName}";
+
+                    // Getter detection
+                    $class = new ReflectionClass(get_class($event->target[0]));
+                    if($class->hasMethod($this->currentSortingFieldGetter))
+                    {
+                        // Sort
+                        usort($event->target, array($this, "sort" . ucfirst($this->sortDirection)));
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * @param $object1 first object to compare
+     * @param $object2 second object to compare
+     */
+    private function sortAsc($object1, $object2)
+    {
+        $fieldValue1 = strtolower($object1->{$this->currentSortingFieldGetter}());
+        $fieldValue2 = strtolower($object2->{$this->currentSortingFieldGetter}());
+        if ($fieldValue1 == $fieldValue2) {
+            return 0;
+        }
+        return ($fieldValue1 > $fieldValue2) ? +1 : -1;
+    }
+
+    /**
+     * @param $object1 first object to compare
+     * @param $object2 second object to compare
+     */
+    private function sortDesc($object1, $object2)
+    {
+        $fieldValue1 = strtolower($object1->{$this->currentSortingFieldGetter}());
+        $fieldValue2 = strtolower($object2->{$this->currentSortingFieldGetter}());
+        if ($fieldValue1 == $fieldValue2) {
+            return 0;
+        }
+        return ($fieldValue1 > $fieldValue2) ? -1 : +1;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            'knp_pager.items' => array('items', 1)
+        );
+    }
+}

--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/SortableSubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/SortableSubscriber.php
@@ -16,6 +16,7 @@ class SortableSubscriber implements EventSubscriberInterface
         $disp->addSubscriber(new ElasticaQuerySubscriber());
         $disp->addSubscriber(new PropelQuerySubscriber());
         $disp->addSubscriber(new SolariumQuerySubscriber());
+        $disp->addSubscriber(new ArraySubscriber());
     }
 
     public static function getSubscribedEvents()


### PR DESCRIPTION
Hi,
Relating [some issues reported](https://github.com/KnpLabs/KnpPaginatorBundle/issues/209), I wrote an ArraySubscriber to allow arrays to be sortable.
I added reflection checks to ensure sort attribute getter would be available on the target entity.

Regarding the implementation, I preferred use 2 distinct callbacks (sortAsc and sortDesc). Although sharing 99% of the code I wanted to avoid "if" check in callback, especially on the large chunks of data.

Let me know if it suits you, or if you have any suggestion to improve.
I currently use Knp-components on a production project, and if it's ok for you it would be great to embed this as a native part.

Cheers for your work,

Nicolas