### PR TITLE
Fix the composer install for PHP 7 and HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,9 @@ matrix:
         - php: hhvm
 
 before_script:
-    - echo 'extension=mongo.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+    # The mongo extension is not yet available on PHP 7
+    - if [[ "$TRAVIS_PHP_VERSION" != "7.0" ]] && [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then echo 'extension=mongo.so' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi
+    - if [[ "$TRAVIS_PHP_VERSION" = "7.0" ]] || [[ "$TRAVIS_PHP_VERSION" = "hhvm" ]]; then composer remove --dev --no-update doctrine/mongodb-odm; fi
     - composer install --prefer-dist
 
 script: phpunit -c tests


### PR DESCRIPTION
The mongo extension is not available for these versions, so the ODM cannot be installed