### PR TITLE
Add getTotalItemCount in PaginationInterface

### DIFF
--- a/src/Knp/Component/Pager/Pagination/PaginationInterface.php
+++ b/src/Knp/Component/Pager/Pagination/PaginationInterface.php
@@ -23,6 +23,11 @@ interface PaginationInterface
      * @param integer $numTotal
      */
     function setTotalItemCount($numTotal);
+    
+    /**
+     * @return integer
+     */
+    function getTotalItemCount();
 
     /**
      * @param mixed $items


### PR DESCRIPTION
The method **getTotalItemCount** must be part of PaginationInterface

```
{# total items count #}
<div class="count">
    {{ pagination.getTotalItemCount }}
</div>
```
