### PR TITLE
Fixed ololoshke_trololoshke alias at count table name

### DIFF
--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/DBALQueryBuilderSubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/DBALQueryBuilderSubscriber.php
@@ -27,7 +27,7 @@ class DBALQueryBuilderSubscriber implements EventSubscriberInterface
             $qb
                 ->resetQueryParts()
                 ->select('count(*) as cnt')
-                ->from('(' . $sql . ')', 'ololoshke_trololoshke')
+                ->from('(' . $sql . ')', 'dbal_count_tbl')
             ;
 
             $event->count = $qb


### PR DESCRIPTION
Renamed 'ololoshke_trololoshke' alias at count table name to 'dbal_count_tbl' in DBAL Query Builder Subscriber.

This fixes [#123](https://github.com/KnpLabs/knp-components/issues/123) Scary "ololoshke_trololoshke" at the end of some queries. It makes easier understanding of query log.
