### PR TITLE
DBALQueryBuilderSubscriber orderBy query part is removed at count query

### DIFF
--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/DBALQueryBuilderSubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/DBALQueryBuilderSubscriber.php
@@ -19,11 +19,17 @@ class DBALQueryBuilderSubscriber implements EventSubscriberInterface
             /** @var $target QueryBuilder */
             $target = $event->target;
         
-            // get the query
-            $sql = $target->getSQL();
-
             // count results
             $qb = clone $target;
+            
+            //reset count orderBy since it can break query and slow it down
+            $qb
+                ->resetQueryPart('orderBy')
+            ;
+            
+            // get the query
+            $sql = $qb->getSQL();
+            
             $qb
                 ->resetQueryParts()
                 ->select('count(*) as cnt')


### PR DESCRIPTION
This is proposed fix to [#149](https://github.com/KnpLabs/knp-components/issues/149)

OrderBy Query Builder part is removed before count query is executed. This fixes MSSQL error when doing count from a VIEW without result limit. It also speeds up count query significantly since order by is not in effect.
