### PR TITLE
Fix memory leak due to Lazy-Loading subscribers

### DIFF
--- a/src/Knp/Component/Pager/Event/Subscriber/Filtration/FiltrationSubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Filtration/FiltrationSubscriber.php
@@ -7,12 +7,25 @@ use Knp\Component\Pager\Event\BeforeEvent;
 
 class FiltrationSubscriber implements EventSubscriberInterface
 {
+    /**
+     * Lazy-load state tracker
+     * @var bool
+     */
+    private $isLoaded = false;
+
     public function before(BeforeEvent $event)
     {
+        // Do not lazy-load more than once
+        if ($this->isLoaded) {
+            return;
+        }
+
         $disp = $event->getEventDispatcher();
         // hook all standard filtration subscribers
         $disp->addSubscriber(new Doctrine\ORM\QuerySubscriber());
         $disp->addSubscriber(new PropelQuerySubscriber());
+
+        $this->isLoaded = true;
     }
 
     public static function getSubscribedEvents()

--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/PaginationSubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/PaginationSubscriber.php
@@ -9,6 +9,12 @@ use Knp\Component\Pager\Pagination\SlidingPagination;
 
 class PaginationSubscriber implements EventSubscriberInterface
 {
+    /**
+     * Lazy-load state tracker
+     * @var bool
+     */
+    private $isLoaded = false;
+
     public function pagination(PaginationEvent $event)
     {
         $event->setPagination(new SlidingPagination);
@@ -17,6 +23,11 @@ class PaginationSubscriber implements EventSubscriberInterface
 
     public function before(BeforeEvent $event)
     {
+        // Do not lazy-load more than once
+        if ($this->isLoaded) {
+            return;
+        }
+
         $disp = $event->getEventDispatcher();
         // hook all standard subscribers
         $disp->addSubscriber(new ArraySubscriber);
@@ -32,6 +43,8 @@ class PaginationSubscriber implements EventSubscriberInterface
         $disp->addSubscriber(new PropelQuerySubscriber);
         $disp->addSubscriber(new SolariumQuerySubscriber());
         $disp->addSubscriber(new ElasticaQuerySubscriber());
+
+        $this->isLoaded = true;
     }
 
     public static function getSubscribedEvents()

--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/SortableSubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/SortableSubscriber.php
@@ -7,8 +7,19 @@ use Knp\Component\Pager\Event\BeforeEvent;
 
 class SortableSubscriber implements EventSubscriberInterface
 {
+    /**
+     * Lazy-load state tracker
+     * @var bool
+     */
+    private $isLoaded = false;
+
     public function before(BeforeEvent $event)
     {
+        // Do not lazy-load more than once
+        if ($this->isLoaded) {
+            return;
+        }
+
         $disp = $event->getEventDispatcher();
         // hook all standard sortable subscribers
         $disp->addSubscriber(new Doctrine\ORM\QuerySubscriber());
@@ -17,6 +28,8 @@ class SortableSubscriber implements EventSubscriberInterface
         $disp->addSubscriber(new PropelQuerySubscriber());
         $disp->addSubscriber(new SolariumQuerySubscriber());
         $disp->addSubscriber(new ArraySubscriber());
+
+        $this->isLoaded = true;
     }
 
     public static function getSubscribedEvents()

--- a/tests/Test/Pager/Subscriber/Filtration/FiltrationSubscriberTest.php
+++ b/tests/Test/Pager/Subscriber/Filtration/FiltrationSubscriberTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use Test\Tool\BaseTestCase;
+use Knp\Component\Pager\Event\Subscriber\Filtration\FiltrationSubscriber;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Knp\Component\Pager\Event\BeforeEvent;
+
+class FiltrationSubscriberTest extends BaseTestCase
+{
+    /**
+     * @test
+     */
+    function shouldRegisterExpectedSubscribersOnlyOnce()
+    {
+        $dispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMock();
+        $dispatcher->expects($this->exactly(2))->method('addSubscriber');
+
+        $subscriber = new FiltrationSubscriber;
+
+        $beforeEvent = new BeforeEvent($dispatcher);
+        $subscriber->before($beforeEvent);
+
+        // Subsequent calls do not add more subscribers
+        $subscriber->before($beforeEvent);
+    }
+}

--- a/tests/Test/Pager/Subscriber/Filtration/FiltrationSubscriberTest.php
+++ b/tests/Test/Pager/Subscriber/Filtration/FiltrationSubscriberTest.php
@@ -2,7 +2,6 @@
 
 use Test\Tool\BaseTestCase;
 use Knp\Component\Pager\Event\Subscriber\Filtration\FiltrationSubscriber;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Knp\Component\Pager\Event\BeforeEvent;
 
 class FiltrationSubscriberTest extends BaseTestCase
@@ -12,7 +11,7 @@ class FiltrationSubscriberTest extends BaseTestCase
      */
     function shouldRegisterExpectedSubscribersOnlyOnce()
     {
-        $dispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMock();
+        $dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
         $dispatcher->expects($this->exactly(2))->method('addSubscriber');
 
         $subscriber = new FiltrationSubscriber;

--- a/tests/Test/Pager/Subscriber/Paginate/PaginationSubscriberTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/PaginationSubscriberTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Test\Tool\BaseTestCase;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Knp\Component\Pager\Event\Subscriber\Paginate\PaginationSubscriber;
 use Knp\Component\Pager\Event\BeforeEvent;
 
@@ -12,7 +11,7 @@ class PaginationSubscriberTest extends BaseTestCase
      */
     function shouldRegisterExpectedSubscribersOnlyOnce()
     {
-        $dispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMock();
+        $dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
         $dispatcher->expects($this->exactly(13))->method('addSubscriber');
 
         $subscriber = new PaginationSubscriber;

--- a/tests/Test/Pager/Subscriber/Paginate/PaginationSubscriberTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/PaginationSubscriberTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use Test\Tool\BaseTestCase;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Knp\Component\Pager\Event\Subscriber\Paginate\PaginationSubscriber;
+use Knp\Component\Pager\Event\BeforeEvent;
+
+class PaginationSubscriberTest extends BaseTestCase
+{
+    /**
+     * @test
+     */
+    function shouldRegisterExpectedSubscribersOnlyOnce()
+    {
+        $dispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMock();
+        $dispatcher->expects($this->exactly(13))->method('addSubscriber');
+
+        $subscriber = new PaginationSubscriber;
+
+        $beforeEvent = new BeforeEvent($dispatcher);
+        $subscriber->before($beforeEvent);
+
+        // Subsequent calls do not add more subscribers
+        $subscriber->before($beforeEvent);
+    }
+}

--- a/tests/Test/Pager/Subscriber/Sortable/SortableSubscriberTest.php
+++ b/tests/Test/Pager/Subscriber/Sortable/SortableSubscriberTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use Test\Tool\BaseTestCase;
+use Knp\Component\Pager\Event\Subscriber\Sortable\SortableSubscriber;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Knp\Component\Pager\Event\BeforeEvent;
+
+class SortableSubscriberTest extends BaseTestCase
+{
+    /**
+     * @test
+     */
+    function shouldRegisterExpectedSubscribersOnlyOnce()
+    {
+        $dispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMock();
+        $dispatcher->expects($this->exactly(6))->method('addSubscriber');
+
+        $subscriber = new SortableSubscriber;
+
+        $beforeEvent = new BeforeEvent($dispatcher);
+        $subscriber->before($beforeEvent);
+
+        // Subsequent calls do not add more subscribers
+        $subscriber->before($beforeEvent);
+    }
+}

--- a/tests/Test/Pager/Subscriber/Sortable/SortableSubscriberTest.php
+++ b/tests/Test/Pager/Subscriber/Sortable/SortableSubscriberTest.php
@@ -2,7 +2,6 @@
 
 use Test\Tool\BaseTestCase;
 use Knp\Component\Pager\Event\Subscriber\Sortable\SortableSubscriber;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Knp\Component\Pager\Event\BeforeEvent;
 
 class SortableSubscriberTest extends BaseTestCase
@@ -12,7 +11,7 @@ class SortableSubscriberTest extends BaseTestCase
      */
     function shouldRegisterExpectedSubscribersOnlyOnce()
     {
-        $dispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMock();
+        $dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')->getMock();
         $dispatcher->expects($this->exactly(6))->method('addSubscriber');
 
         $subscriber = new SortableSubscriber;


### PR DESCRIPTION
Fixes issue #151, by adding state to the lazy-loading event subscribers.

This prevents multiple calls to `Paginator#paginate()` from adding duplicate subscribers to the Event Dispatcher, which can manifest as a memory leak if paginate is repeatedly called.

By putting the state inside the lazy-loading Event Subscribers this keeps the lazy-load mechanism in the domain of the subscriber, leaving the Paginator agnostic to the method used to populate the EventDispatcher.

Tests have been added to confirm this behaviour.