### PR TITLE
Filtration with join: There is no component aliased by [ x] in the given Query

### DIFF
--- a/src/Knp/Component/Pager/Event/Subscriber/Filtration/Doctrine/ORM/Query/WhereWalker.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Filtration/Doctrine/ORM/Query/WhereWalker.php
@@ -51,7 +51,7 @@ class WhereWalker extends TreeWalkerAdapter
             $parts = explode('.', $column);
             $field = end($parts);
             if (2 <= count($parts)) {
-                $alias = reset($parts);
+                $alias = trim(reset($parts));
                 if (!array_key_exists($alias, $components)) {
                     throw new \UnexpectedValueException("There is no component aliased by [{$alias}] in the given Query");
                 }


### PR DESCRIPTION
When you perform the filter based on columns of separate tables joined with join, the error is displayed:
There is no component aliased by [ x] in the given Query

Scenario (OneToMany):
Maker  1:N Product

Properties considered:
Maker 
- name

Product
- model

Wanting to filter based on the product "model" property but also considering the "name" of the maker.

Twig
{{ knp_pagination_filter(pagination, {'p.model, m.name':''}) }}

QueryBuilder
$qb->select('p')
  ->from'AppBundle\Entity\Product', 'p')
  ->join('p.maker', 'm', 'WITH')
  ->orderBy('p.id', 'desc');

When executed, the displayed error:
"There is no component aliased by [ m] in the given Query"

The error is raised because the key generated with the alias "m" is not found in the "components" array, but the key is generated with a blank before starting the alias, [ m] and not [m].
The solution found (so far) was to "clean" the string so that the space is removed, according to the code.