### PR TITLE
fix ArraySubscriber

### DIFF
--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/ArraySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/ArraySubscriber.php
@@ -42,7 +42,7 @@ class ArraySubscriber implements EventSubscriberInterface
                     $this->currentSortingFieldGetter = "get{$sortFieldName}";
 
                     // Getter detection
-                    $class = new ReflectionClass(get_class($event->target[0]));
+                    $class = new ReflectionClass(get_class(current($event->target)));
                     if($class->hasMethod($this->currentSortingFieldGetter)) {
                         // Sort
                         usort($event->target, array($this, "sort" . ucfirst($this->sortDirection)));


### PR DESCRIPTION
If array of Objects don't have object with key 0, I got Notice.

`
Notice: Undefined offset: 0
in vendor/knplabs/knp-components/src/Knp/Component/Pager/Event/Subscriber/Sortable/ArraySubscriber.php at line 45
`

My fix resolve this bug