### PR TITLE
Utilize PropertyAccess component for sorting arrays

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,12 @@
         "doctrine/phpcr-odm": "~1.2",
         "jackalope/jackalope-doctrine-dbal": "~1.2",
         "phpunit/phpunit": "~4.2",
-        "ruflin/elastica": "~1.0"
+        "ruflin/elastica": "~1.0",
+        "symfony/property-access": ">=2.3"
     },
 
     "suggest": {
+        "symfony/property-access": "To allow sorting arrays",
         "doctrine/orm" : "to allow usage pagination with Doctrine ORM",
         "doctrine/common" : "to allow usage pagination with Doctrine ArrayCollection",
         "doctrine/mongodb-odm" : "to allow usage pagination with Doctrine ODM MongoDB",

--- a/tests/Test/Pager/Subscriber/Sortable/ArraySubscriberTest.php
+++ b/tests/Test/Pager/Subscriber/Sortable/ArraySubscriberTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Test\Pager\Subscriber\Sortable;
+
+use Knp\Component\Pager\Event\ItemsEvent;
+use Knp\Component\Pager\Event\Subscriber\Sortable\ArraySubscriber;
+use Test\Tool\BaseTestCase;
+
+class ArraySubscriberTest extends BaseTestCase
+{
+    /**
+     * @test
+     */
+    public function shouldSort()
+    {
+        $array = array(
+            array('entry' => array('sortProperty' => 2)),
+            array('entry' => array('sortProperty' => 3)),
+            array('entry' => array('sortProperty' => 1)),
+        );
+
+        $itemsEvent = new ItemsEvent(0, 10);
+        $itemsEvent->target = &$array;
+        $itemsEvent->options = array('sortFieldParameterName' => 'sort', 'sortDirectionParameterName' => 'ord');
+        $_GET = array('sort' => '[entry][sortProperty]', 'ord' => 'asc');
+
+        $this->assertEquals(2, $array[0]['entry']['sortProperty']);
+        $arraySubscriber = new ArraySubscriber();
+        $arraySubscriber->items($itemsEvent);
+        $this->assertEquals(1, $array[0]['entry']['sortProperty']);
+        $_GET ['ord'] = 'desc';
+        $arraySubscriber->items($itemsEvent);
+        $this->assertEquals(3, $array[0]['entry']['sortProperty']);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSortWithCustomCallback()
+    {
+        $array = array(
+            array('name' => 'hot'),
+            array('name' => 'cold'),
+            array('name' => 'hot'),
+        );
+
+        $itemsEvent = new ItemsEvent(0, 10);
+        $itemsEvent->target = &$array;
+        $itemsEvent->options = array(
+            'sortFieldParameterName' => 'sort',
+            'sortDirectionParameterName' => 'ord',
+            'sortFunction' => function (&$target, $sortField, $sortDirection) {
+                usort($target, function($object1, $object2) use ($sortField, $sortDirection) {
+                    if ($object1[$sortField] == $object2[$sortField]) {
+                        return 0;
+                    }
+
+                    return ($object1[$sortField] == 'hot' ? 1 : -1) * ($sortDirection == 'asc' ? 1 : -1);
+                });
+            },
+        );
+        $_GET = array('sort' => '.name', 'ord' => 'asc');
+
+        $this->assertEquals('hot', $array[0]['name']);
+        $arraySubscriber = new ArraySubscriber();
+        $arraySubscriber->items($itemsEvent);
+        $this->assertEquals('cold', $array[0]['name']);
+        $_GET['ord'] = 'desc';
+        $arraySubscriber->items($itemsEvent);
+        $this->assertEquals('hot', $array[0]['name']);
+
+    }
+}


### PR DESCRIPTION
The only data structure currenty ArraySubscriber is able to sort is `object[]`, where object MUST have public `get{sortPropertyName}` method. This PR utilizes symfony propertyaccess component instead, which allows to sort pure array, nested structure, objects with issers, __call methods, objects without any getter but with pulic properties, etc. 

Besides this main feature of this PR I changed some things, like I uncommented whitelist, turned strtolower into mb_strtolower for utf support, introduced ability to change built in sorting function with custom one and allowed to sort by other data types than strings, such as dates