### PR TITLE
Remove PHP 5.3.3 from build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
         - $HOME/.composer/cache
 
 php:
-    - 5.3.3
     - 5.3
     - 5.4
     - 5.5


### PR DESCRIPTION
Current Travis documentations states:
> The OpenSSL extension is switched off on php 5.3.3 because of compilation problems with OpenSSL 1.0.

This is why a good share of PRs is broken.