### PR TITLE
move interfaces to PaginationInterface

### DIFF
--- a/src/Knp/Component/Pager/Pagination/AbstractPagination.php
+++ b/src/Knp/Component/Pager/Pagination/AbstractPagination.php
@@ -2,9 +2,7 @@
 
 namespace Knp\Component\Pager\Pagination;
 
-use Countable, Iterator, ArrayAccess;
-
-abstract class AbstractPagination implements PaginationInterface, Countable, Iterator, ArrayAccess
+abstract class AbstractPagination implements PaginationInterface
 {
     protected $currentPageNumber;
     protected $numItemsPerPage;

--- a/src/Knp/Component/Pager/Pagination/PaginationInterface.php
+++ b/src/Knp/Component/Pager/Pagination/PaginationInterface.php
@@ -2,12 +2,14 @@
 
 namespace Knp\Component\Pager\Pagination;
 
+use Countable, Iterator, ArrayAccess;
+
 /**
  * Pagination interface strictly defines
  * the methods - paginator will use to populate the
  * pagination data
  */
-interface PaginationInterface
+interface PaginationInterface extends Countable, Iterator, ArrayAccess
 {
     /**
      * @param integer $pageNumber


### PR DESCRIPTION
Use case: you typehint a method to return a `PaginationInterface`, then you use the results in a `foreach` loop.
Example:
```php
function foo(): PaginationInterface
{
    $pagination = '...';
    return $pagination;
}

$pagination = foo();
foreach ($pagination as $item) {
    // ...
}
```
if you do a static analysis on the example code, you get a warning because the `foreach` loop is not using an Iterator. The same applies if you want to do a `count($paginator)`

This PR is solving the question, moving the interfaces from `AbstractPagination` to `PaginationInterface`

