### PR TITLE
replace common magic strings with constants

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
         - $HOME/.composer/cache
 
 php:
-    - 5.3
     - 5.4
     - 5.5
     - 5.6
@@ -15,6 +14,9 @@ php:
     - hhvm
 
 matrix:
+    include:
+        - php: 5.3
+          dist: precise
     allow_failures:
         - php: 7.0
         - php: hhvm

--- a/src/Knp/Component/Pager/Event/Subscriber/Filtration/Doctrine/ORM/QuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Filtration/Doctrine/ORM/QuerySubscriber.php
@@ -6,6 +6,7 @@ use Doctrine\ORM\Query;
 use Knp\Component\Pager\Event\ItemsEvent;
 use Knp\Component\Pager\Event\Subscriber\Filtration\Doctrine\ORM\Query\WhereWalker;
 use Knp\Component\Pager\Event\Subscriber\Paginate\Doctrine\ORM\Query\Helper as QueryHelper;
+use Knp\Component\Pager\PaginatorInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class QuerySubscriber implements EventSubscriberInterface
@@ -13,17 +14,17 @@ class QuerySubscriber implements EventSubscriberInterface
     public function items(ItemsEvent $event)
     {
         if ($event->target instanceof Query) {
-            if (!isset($_GET[$event->options['filterValueParameterName']]) || (empty($_GET[$event->options['filterValueParameterName']]) && $_GET[$event->options['filterValueParameterName']] !== "0")) {
+            if (!isset($_GET[$event->options[PaginatorInterface::FILTER_VALUE_PARAMETER_NAME]]) || (empty($_GET[$event->options[PaginatorInterface::FILTER_VALUE_PARAMETER_NAME]]) && $_GET[$event->options[PaginatorInterface::FILTER_VALUE_PARAMETER_NAME]] !== "0")) {
                 return;
             }
-            if (!empty($_GET[$event->options['filterFieldParameterName']])) {
-                $columns = $_GET[$event->options['filterFieldParameterName']];
-            } elseif (!empty($event->options['defaultFilterFields'])) {
-                $columns = $event->options['defaultFilterFields'];
+            if (!empty($_GET[$event->options[PaginatorInterface::FILTER_FIELD_PARAMETER_NAME]])) {
+                $columns = $_GET[$event->options[PaginatorInterface::FILTER_FIELD_PARAMETER_NAME]];
+            } elseif (!empty($event->options[PaginatorInterface::DEFAULT_FILTER_FIELDS])) {
+                $columns = $event->options[PaginatorInterface::DEFAULT_FILTER_FIELDS];
             } else {
                 return;
             }
-            $value = $_GET[$event->options['filterValueParameterName']];
+            $value = $_GET[$event->options[PaginatorInterface::FILTER_VALUE_PARAMETER_NAME]];
             if (false !== strpos($value, '*')) {
                 $value = str_replace('*', '%', $value);
             }
@@ -31,9 +32,9 @@ class QuerySubscriber implements EventSubscriberInterface
                 $columns = explode(',', $columns);
             }
             $columns = (array) $columns;
-            if (isset($event->options['filterFieldWhitelist'])) {
+            if (isset($event->options[PaginatorInterface::FILTER_FIELD_WHITELIST])) {
                 foreach ($columns as $column) {
-                    if (!in_array($column, $event->options['filterFieldWhitelist'])) {
+                    if (!in_array($column, $event->options[PaginatorInterface::FILTER_FIELD_WHITELIST])) {
                         throw new \UnexpectedValueException("Cannot filter by: [{$column}] this field is not in whitelist");
                     }
                 }

--- a/src/Knp/Component/Pager/Event/Subscriber/Filtration/PropelQuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Filtration/PropelQuerySubscriber.php
@@ -2,6 +2,7 @@
 
 namespace Knp\Component\Pager\Event\Subscriber\Filtration;
 
+use Knp\Component\Pager\PaginatorInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Knp\Component\Pager\Event\ItemsEvent;
 
@@ -11,13 +12,13 @@ class PropelQuerySubscriber implements EventSubscriberInterface
     {
         $query = $event->target;
         if ($query instanceof \ModelCriteria) {
-            if (empty($_GET[$event->options['filterValueParameterName']])) {
+            if (empty($_GET[$event->options[PaginatorInterface::FILTER_VALUE_PARAMETER_NAME]])) {
                 return;
             }
-            if (!empty($_GET[$event->options['filterFieldParameterName']])) {
-                $columns = $_GET[$event->options['filterFieldParameterName']];
-            } elseif (!empty($event->options['defaultFilterFields'])) {
-                $columns = $event->options['defaultFilterFields'];
+            if (!empty($_GET[$event->options[PaginatorInterface::FILTER_FIELD_PARAMETER_NAME]])) {
+                $columns = $_GET[$event->options[PaginatorInterface::FILTER_FIELD_PARAMETER_NAME]];
+            } elseif (!empty($event->options[PaginatorInterface::DEFAULT_FILTER_FIELDS])) {
+                $columns = $event->options[PaginatorInterface::DEFAULT_FILTER_FIELDS];
             } else {
                 return;
             }
@@ -25,14 +26,14 @@ class PropelQuerySubscriber implements EventSubscriberInterface
                 $columns = explode(',', $columns);
             }
             $columns = (array) $columns;
-            if (isset($event->options['filterFieldWhitelist'])) {
+            if (isset($event->options[PaginatorInterface::FILTER_FIELD_WHITELIST])) {
                 foreach ($columns as $column) {
-                    if (!in_array($column, $event->options['filterFieldWhitelist'])) {
+                    if (!in_array($column, $event->options[PaginatorInterface::FILTER_FIELD_WHITELIST])) {
                         throw new \UnexpectedValueException("Cannot filter by: [{$column}] this field is not in whitelist");
                     }
                 }
             }
-            $value = $_GET[$event->options['filterValueParameterName']];
+            $value = $_GET[$event->options[PaginatorInterface::FILTER_VALUE_PARAMETER_NAME]];
             $criteria = \Criteria::EQUAL;
             if (false !== strpos($value, '*')) {
                 $value = str_replace('*', '%', $value);

--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/ORM/QuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/ORM/QuerySubscriber.php
@@ -53,12 +53,12 @@ class QuerySubscriber implements EventSubscriberInterface
                 if ($useDoctrineWalkers) {
                     $countQuery->setHint(
                         DoctrineCountWalker::HINT_DISTINCT,
-                        $event->options['distinct']
+                        $event->options[PaginatorInterface::DISTINCT]
                     );
                 } else {
                     $countQuery->setHint(
                         CountWalker::HINT_DISTINCT,
-                        $event->options['distinct']
+                        $event->options[PaginatorInterface::DISTINCT]
                     );
                 }
                 $countQuery
@@ -75,7 +75,7 @@ class QuerySubscriber implements EventSubscriberInterface
             // process items
             $result = null;
             if ($event->count) {
-                if ($event->options['distinct']) {
+                if ($event->options[PaginatorInterface::DISTINCT]) {
                     $limitSubQuery = QueryHelper::cloneQuery($event->target);
                     $limitSubQuery
                         ->setFirstResult($event->getOffset())

--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/ORM/QuerySubscriber/UsesPaginator.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/ORM/QuerySubscriber/UsesPaginator.php
@@ -2,6 +2,7 @@
 
 namespace Knp\Component\Pager\Event\Subscriber\Paginate\Doctrine\ORM\QuerySubscriber;
 
+use Knp\Component\Pager\PaginatorInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Knp\Component\Pager\Event\ItemsEvent;
 use Knp\Component\Pager\Event\Subscriber\Paginate\Doctrine\ORM\QuerySubscriber;
@@ -31,14 +32,14 @@ class UsesPaginator implements EventSubscriberInterface
         $event->target
             ->setFirstResult($event->getOffset())
             ->setMaxResults($event->getLimit())
-            ->setHint(CountWalker::HINT_DISTINCT, $event->options['distinct'])
+            ->setHint(CountWalker::HINT_DISTINCT, $event->options[PaginatorInterface::DISTINCT])
         ;
 
         $fetchJoinCollection = true;
         if ($event->target->hasHint(self::HINT_FETCH_JOIN_COLLECTION)) {
             $fetchJoinCollection = $event->target->getHint(self::HINT_FETCH_JOIN_COLLECTION);
-        } else if (isset($event->options['distinct'])) {
-            $fetchJoinCollection = $event->options['distinct'];
+        } else if (isset($event->options[PaginatorInterface::DISTINCT])) {
+            $fetchJoinCollection = $event->options[PaginatorInterface::DISTINCT];
         }
 
         $paginator = new Paginator($event->target, $fetchJoinCollection);

--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/PropelQuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/PropelQuerySubscriber.php
@@ -18,7 +18,7 @@ class PropelQuerySubscriber implements EventSubscriberInterface
                 ->limit(0)
                 ->offset(0)
             ;
-            if ($event->options['distinct']) {
+            if ($event->options[PaginatorInterface::DISTINCT]) {
                 $countQuery->distinct();
             }
             $event->count = intval($countQuery->count());
@@ -26,7 +26,7 @@ class PropelQuerySubscriber implements EventSubscriberInterface
             $result = null;
             if ($event->count) {
                 $resultQuery = clone $event->target;
-                if ($event->options['distinct']) {
+                if ($event->options[PaginatorInterface::DISTINCT]) {
                     $resultQuery->distinct();
                 }
                 $resultQuery

--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/ArraySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/ArraySubscriber.php
@@ -6,6 +6,7 @@ use Knp\Component\Pager\Event\ItemsEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use Knp\Component\Pager\PaginatorInterface;
 
 class ArraySubscriber implements EventSubscriberInterface
 {
@@ -35,16 +36,16 @@ class ArraySubscriber implements EventSubscriberInterface
 
     public function items(ItemsEvent $event)
     {
-        if (!is_array($event->target) || empty($_GET[$event->options['sortFieldParameterName']])) {
+        if (!is_array($event->target) || empty($_GET[$event->options[PaginatorInterface::SORT_FIELD_PARAMETER_NAME]])) {
             return;
         }
 
-        if (isset($event->options['sortFieldWhitelist']) && !in_array($_GET[$event->options['sortFieldParameterName']], $event->options['sortFieldWhitelist'])) {
-            throw new \UnexpectedValueException("Cannot sort by: [{$_GET[$event->options['sortFieldParameterName']]}] this field is not in whitelist");
+        if (isset($event->options[PaginatorInterface::SORT_FIELD_WHITELIST]) && !in_array($_GET[$event->options[PaginatorInterface::SORT_FIELD_PARAMETER_NAME]], $event->options[PaginatorInterface::SORT_FIELD_WHITELIST])) {
+            throw new \UnexpectedValueException("Cannot sort by: [{$_GET[$event->options[PaginatorInterface::SORT_FIELD_PARAMETER_NAME]]}] this field is not in whitelist");
         }
 
         $sortFunction = isset($event->options['sortFunction']) ? $event->options['sortFunction'] : array($this, 'proxySortFunction');
-        $sortField = $_GET[$event->options['sortFieldParameterName']];
+        $sortField = $_GET[$event->options[PaginatorInterface::SORT_FIELD_PARAMETER_NAME]];
 
         // compatibility layer
         if ($sortField[0] === '.') {
@@ -54,7 +55,7 @@ class ArraySubscriber implements EventSubscriberInterface
         call_user_func_array($sortFunction, array(
             &$event->target,
             $sortField,
-            isset($_GET[$event->options['sortDirectionParameterName']]) && strtolower($_GET[$event->options['sortDirectionParameterName']]) === 'asc' ? 'asc' : 'desc'
+            isset($_GET[$event->options[PaginatorInterface::SORT_DIRECTION_PARAMETER_NAME]]) && strtolower($_GET[$event->options[PaginatorInterface::SORT_DIRECTION_PARAMETER_NAME]]) === 'asc' ? 'asc' : 'desc'
         ));
     }
 

--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/Doctrine/ODM/MongoDB/QuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/Doctrine/ODM/MongoDB/QuerySubscriber.php
@@ -5,18 +5,19 @@ namespace Knp\Component\Pager\Event\Subscriber\Sortable\Doctrine\ODM\MongoDB;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Knp\Component\Pager\Event\ItemsEvent;
 use Doctrine\ODM\MongoDB\Query\Query;
+use Knp\Component\Pager\PaginatorInterface;
 
 class QuerySubscriber implements EventSubscriberInterface
 {
     public function items(ItemsEvent $event)
     {
         if ($event->target instanceof Query) {
-            if (isset($_GET[$event->options['sortFieldParameterName']])) {
-                $field = $_GET[$event->options['sortFieldParameterName']];
-                $dir = strtolower($_GET[$event->options['sortDirectionParameterName']]) == 'asc' ? 1 : -1;
+            if (isset($_GET[$event->options[PaginatorInterface::SORT_FIELD_PARAMETER_NAME]])) {
+                $field = $_GET[$event->options[PaginatorInterface::SORT_FIELD_PARAMETER_NAME]];
+                $dir = strtolower($_GET[$event->options[PaginatorInterface::SORT_DIRECTION_PARAMETER_NAME]]) == 'asc' ? 1 : -1;
 
-                if (isset($event->options['sortFieldWhitelist'])) {
-                    if (!in_array($field, $event->options['sortFieldWhitelist'])) {
+                if (isset($event->options[PaginatorInterface::SORT_FIELD_WHITELIST])) {
+                    if (!in_array($field, $event->options[PaginatorInterface::SORT_FIELD_WHITELIST])) {
                         throw new \UnexpectedValueException("Cannot sort by: [{$field}] this field is not in whitelist");
                     }
                 }

--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/Doctrine/ORM/QuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/Doctrine/ORM/QuerySubscriber.php
@@ -7,22 +7,23 @@ use Knp\Component\Pager\Event\ItemsEvent;
 use Knp\Component\Pager\Event\Subscriber\Sortable\Doctrine\ORM\Query\OrderByWalker;
 use Knp\Component\Pager\Event\Subscriber\Paginate\Doctrine\ORM\Query\Helper as QueryHelper;
 use Doctrine\ORM\Query;
+use Knp\Component\Pager\PaginatorInterface;
 
 class QuerySubscriber implements EventSubscriberInterface
 {
     public function items(ItemsEvent $event)
     {
         if ($event->target instanceof Query) {
-            if (isset($_GET[$event->options['sortFieldParameterName']])) {
-                $dir = isset($_GET[$event->options['sortDirectionParameterName']]) && strtolower($_GET[$event->options['sortDirectionParameterName']]) === 'asc' ? 'asc' : 'desc';
+            if (isset($_GET[$event->options[PaginatorInterface::SORT_FIELD_PARAMETER_NAME]])) {
+                $dir = isset($_GET[$event->options[PaginatorInterface::SORT_DIRECTION_PARAMETER_NAME]]) && strtolower($_GET[$event->options[PaginatorInterface::SORT_DIRECTION_PARAMETER_NAME]]) === 'asc' ? 'asc' : 'desc';
 
-                if (isset($event->options['sortFieldWhitelist'])) {
-                    if (!in_array($_GET[$event->options['sortFieldParameterName']], $event->options['sortFieldWhitelist'])) {
-                        throw new \UnexpectedValueException("Cannot sort by: [{$_GET[$event->options['sortFieldParameterName']]}] this field is not in whitelist");
+                if (isset($event->options[PaginatorInterface::SORT_FIELD_WHITELIST])) {
+                    if (!in_array($_GET[$event->options[PaginatorInterface::SORT_FIELD_PARAMETER_NAME]], $event->options[PaginatorInterface::SORT_FIELD_WHITELIST])) {
+                        throw new \UnexpectedValueException("Cannot sort by: [{$_GET[$event->options[PaginatorInterface::SORT_FIELD_PARAMETER_NAME]]}] this field is not in whitelist");
                     }
                 }
 
-                $sortFieldParameterNames = $_GET[$event->options['sortFieldParameterName']];
+                $sortFieldParameterNames = $_GET[$event->options[PaginatorInterface::SORT_FIELD_PARAMETER_NAME]];
                 $fields = array();
                 $aliases = array();
                 foreach (explode('+', $sortFieldParameterNames) as $sortFieldParameterName) {

--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/ElasticaQuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/ElasticaQuerySubscriber.php
@@ -6,6 +6,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Knp\Component\Pager\Event\ItemsEvent;
 use Elastica\Query;
 use Elastica\SearchableInterface;
+use Knp\Component\Pager\PaginatorInterface;
 
 class ElasticaQuerySubscriber implements EventSubscriberInterface
 {
@@ -14,11 +15,11 @@ class ElasticaQuerySubscriber implements EventSubscriberInterface
         if (is_array($event->target) && 2 === count($event->target) && reset($event->target) instanceof SearchableInterface && end($event->target) instanceof Query) {
             list($searchable, $query) = $event->target;
 
-            if (isset($_GET[$event->options['sortFieldParameterName']])) {
-                $field = $_GET[$event->options['sortFieldParameterName']];
-                $dir   = isset($_GET[$event->options['sortDirectionParameterName']]) && strtolower($_GET[$event->options['sortDirectionParameterName']]) === 'asc' ? 'asc' : 'desc';
+            if (isset($_GET[$event->options[PaginatorInterface::SORT_FIELD_PARAMETER_NAME]])) {
+                $field = $_GET[$event->options[PaginatorInterface::SORT_FIELD_PARAMETER_NAME]];
+                $dir   = isset($_GET[$event->options[PaginatorInterface::SORT_DIRECTION_PARAMETER_NAME]]) && strtolower($_GET[$event->options[PaginatorInterface::SORT_DIRECTION_PARAMETER_NAME]]) === 'asc' ? 'asc' : 'desc';
 
-                if (isset($event->options['sortFieldWhitelist']) && !in_array($field, $event->options['sortFieldWhitelist'])) {
+                if (isset($event->options[PaginatorInterface::SORT_FIELD_WHITELIST]) && !in_array($field, $event->options[PaginatorInterface::SORT_FIELD_WHITELIST])) {
                     throw new \UnexpectedValueException(sprintf('Cannot sort by: [%s] this field is not in whitelist',$field));
                 }
 

--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/PropelQuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/PropelQuerySubscriber.php
@@ -2,6 +2,7 @@
 
 namespace Knp\Component\Pager\Event\Subscriber\Sortable;
 
+use Knp\Component\Pager\PaginatorInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Knp\Component\Pager\Event\ItemsEvent;
 
@@ -11,16 +12,16 @@ class PropelQuerySubscriber implements EventSubscriberInterface
     {
         $query = $event->target;
         if ($query instanceof \ModelCriteria) {
-            if (isset($_GET[$event->options['sortFieldParameterName']])) {
-                $part = $_GET[$event->options['sortFieldParameterName']];
-                $directionParam = $event->options['sortDirectionParameterName'];
+            if (isset($_GET[$event->options[PaginatorInterface::SORT_FIELD_PARAMETER_NAME]])) {
+                $part = $_GET[$event->options[PaginatorInterface::SORT_FIELD_PARAMETER_NAME]];
+                $directionParam = $event->options[PaginatorInterface::SORT_DIRECTION_PARAMETER_NAME];
 
                 $direction = (isset($_GET[$directionParam]) && strtolower($_GET[$directionParam]) === 'asc')
                                 ? 'asc' : 'desc';
 
-                if (isset($event->options['sortFieldWhitelist'])) {
-                    if (!in_array($_GET[$event->options['sortFieldParameterName']], $event->options['sortFieldWhitelist'])) {
-                        throw new \UnexpectedValueException("Cannot sort by: [{$_GET[$event->options['sortFieldParameterName']]}] this field is not in whitelist");
+                if (isset($event->options[PaginatorInterface::SORT_FIELD_WHITELIST])) {
+                    if (!in_array($_GET[$event->options[PaginatorInterface::SORT_FIELD_PARAMETER_NAME]], $event->options[PaginatorInterface::SORT_FIELD_WHITELIST])) {
+                        throw new \UnexpectedValueException("Cannot sort by: [{$_GET[$event->options[PaginatorInterface::SORT_FIELD_PARAMETER_NAME]]}] this field is not in whitelist");
                     }
                 }
 

--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/SolariumQuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/SolariumQuerySubscriber.php
@@ -3,6 +3,7 @@
 namespace Knp\Component\Pager\Event\Subscriber\Sortable;
 
 use Knp\Component\Pager\Event\ItemsEvent;
+use Knp\Component\Pager\PaginatorInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -19,14 +20,14 @@ class SolariumQuerySubscriber implements EventSubscriberInterface
             list($client, $query) = $values;
 
             if ($client instanceof \Solarium\Client && $query instanceof \Solarium\QueryType\Select\Query\Query) {
-                if (isset($_GET[$event->options['sortFieldParameterName']])) {
-                    if (isset($event->options['sortFieldWhitelist'])) {
-                        if (!in_array($_GET[$event->options['sortFieldParameterName']], $event->options['sortFieldWhitelist'])) {
-                            throw new \UnexpectedValueException("Cannot sort by: [{$_GET[$event->options['sortFieldParameterName']]}] this field is not in whitelist");
+                if (isset($_GET[$event->options[PaginatorInterface::SORT_FIELD_PARAMETER_NAME]])) {
+                    if (isset($event->options[PaginatorInterface::SORT_FIELD_WHITELIST])) {
+                        if (!in_array($_GET[$event->options[PaginatorInterface::SORT_FIELD_PARAMETER_NAME]], $event->options[PaginatorInterface::SORT_FIELD_WHITELIST])) {
+                            throw new \UnexpectedValueException("Cannot sort by: [{$_GET[$event->options[PaginatorInterface::SORT_FIELD_PARAMETER_NAME]]}] this field is not in whitelist");
                         }
                     }
 
-                    $query->addSort($_GET[$event->options['sortFieldParameterName']], $this->getSortDirection($event));
+                    $query->addSort($_GET[$event->options[PaginatorInterface::SORT_FIELD_PARAMETER_NAME]], $this->getSortDirection($event));
                 }
             }
         }
@@ -42,7 +43,7 @@ class SolariumQuerySubscriber implements EventSubscriberInterface
 
     private function getSortDirection($event)
     {
-        return isset($_GET[$event->options['sortDirectionParameterName']]) &&
-            strtolower($_GET[$event->options['sortDirectionParameterName']]) === 'asc' ? 'asc' : 'desc';
+        return isset($_GET[$event->options[PaginatorInterface::SORT_DIRECTION_PARAMETER_NAME]]) &&
+            strtolower($_GET[$event->options[PaginatorInterface::SORT_DIRECTION_PARAMETER_NAME]]) === 'asc' ? 'asc' : 'desc';
     }
 }

--- a/src/Knp/Component/Pager/Paginator.php
+++ b/src/Knp/Component/Pager/Paginator.php
@@ -28,12 +28,12 @@ class Paginator implements PaginatorInterface
      * @var array
      */
     protected $defaultOptions = array(
-        'pageParameterName' => 'page',
-        'sortFieldParameterName' => 'sort',
-        'sortDirectionParameterName' => 'direction',
-        'filterFieldParameterName' => 'filterParam',
-        'filterValueParameterName' => 'filterValue',
-        'distinct' => true
+        self::PAGE_PARAMETER_NAME => 'page',
+        self::SORT_FIELD_PARAMETER_NAME => 'sort',
+        self::SORT_DIRECTION_PARAMETER_NAME => 'direction',
+        self::FILTER_FIELD_PARAMETER_NAME => 'filterParam',
+        self::FILTER_VALUE_PARAMETER_NAME => 'filterValue',
+        self::DISTINCT => true
     );
 
     /**
@@ -90,16 +90,16 @@ class Paginator implements PaginatorInterface
         $options = array_merge($this->defaultOptions, $options);
 
         // normalize default sort field
-        if (isset($options['defaultSortFieldName']) && is_array($options['defaultSortFieldName'])) {
-            $options['defaultSortFieldName'] = implode('+', $options['defaultSortFieldName']);
+        if (isset($options[self::DEFAULT_SORT_FIELD_NAME]) && is_array($options[self::DEFAULT_SORT_FIELD_NAME])) {
+            $options[self::DEFAULT_SORT_FIELD_NAME] = implode('+', $options[self::DEFAULT_SORT_FIELD_NAME]);
         }
         
         // default sort field and direction are set based on options (if available)
-        if (!isset($_GET[$options['sortFieldParameterName']]) && isset($options['defaultSortFieldName'])) {
-            $_GET[$options['sortFieldParameterName']] = $options['defaultSortFieldName'];
+        if (!isset($_GET[$options[self::SORT_FIELD_PARAMETER_NAME]]) && isset($options[self::DEFAULT_SORT_FIELD_NAME])) {
+            $_GET[$options[self::SORT_FIELD_PARAMETER_NAME]] = $options[self::DEFAULT_SORT_FIELD_NAME];
             
-            if (!isset($_GET[$options['sortDirectionParameterName']])) {
-                $_GET[$options['sortDirectionParameterName']] = isset($options['defaultSortDirection']) ? $options['defaultSortDirection'] : 'asc';
+            if (!isset($_GET[$options[self::SORT_DIRECTION_PARAMETER_NAME]])) {
+                $_GET[$options[self::SORT_DIRECTION_PARAMETER_NAME]] = isset($options[self::DEFAULT_SORT_DIRECTION]) ? $options[self::DEFAULT_SORT_DIRECTION] : 'asc';
             }
         }
         

--- a/src/Knp/Component/Pager/PaginatorInterface.php
+++ b/src/Knp/Component/Pager/PaginatorInterface.php
@@ -7,6 +7,18 @@ namespace Knp\Component\Pager;
  */
 interface PaginatorInterface
 {
+    const DEFAULT_SORT_FIELD_NAME = 'defaultSortFieldName';
+    const DEFAULT_SORT_DIRECTION = 'defaultSortDirection';
+    const DEFAULT_FILTER_FIELDS = 'defaultFilterFields';
+    const SORT_FIELD_PARAMETER_NAME = 'sortFieldParameterName';
+    const SORT_FIELD_WHITELIST = 'sortFieldWhitelist';
+    const SORT_DIRECTION_PARAMETER_NAME = 'sortDirectionParameterName';
+    const PAGE_PARAMETER_NAME = 'pageParameterName';
+    const FILTER_FIELD_PARAMETER_NAME = 'filterFieldParameterName';
+    const FILTER_VALUE_PARAMETER_NAME = 'filterValueParameterName';
+    const FILTER_FIELD_WHITELIST = 'filterFieldWhitelist';
+    const DISTINCT = 'distinct';
+
     /**
      * Paginates anything (depending on event listeners)
      * into Pagination object, which is a view targeted

--- a/tests/Test/Pager/Pagination/AbstractPaginationTest.php
+++ b/tests/Test/Pager/Pagination/AbstractPaginationTest.php
@@ -6,6 +6,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 use Test\Mock\PaginationSubscriber as MockPaginationSubscriber;
 use Test\Mock\CustomParameterSubscriber;
 use Knp\Component\Pager\Event\Subscriber\Paginate\ArraySubscriber;
+use Knp\Component\Pager\PaginatorInterface;
 
 class AbstractPaginationTest extends BaseTestCase
 {
@@ -23,40 +24,40 @@ class AbstractPaginationTest extends BaseTestCase
         $view = $p->paginate($items, 1, 10);
 
         // test default names first
-        $this->assertEquals('page', $view->getPaginatorOption('pageParameterName'));
-        $this->assertEquals('sort', $view->getPaginatorOption('sortFieldParameterName'));
-        $this->assertEquals('direction', $view->getPaginatorOption('sortDirectionParameterName'));
-        $this->assertTrue($view->getPaginatorOption('distinct'));
-        $this->assertNull($view->getPaginatorOption('sortFieldWhitelist'));
+        $this->assertEquals('page', $view->getPaginatorOption(PaginatorInterface::PAGE_PARAMETER_NAME));
+        $this->assertEquals('sort', $view->getPaginatorOption(PaginatorInterface::SORT_FIELD_PARAMETER_NAME));
+        $this->assertEquals('direction', $view->getPaginatorOption(PaginatorInterface::SORT_DIRECTION_PARAMETER_NAME));
+        $this->assertTrue($view->getPaginatorOption(PaginatorInterface::DISTINCT));
+        $this->assertNull($view->getPaginatorOption(PaginatorInterface::SORT_FIELD_WHITELIST));
 
         // now customize
         $options = array(
-            'pageParameterName' => 'p',
-            'sortFieldParameterName' => 's',
-            'sortDirectionParameterName' => 'd',
-            'distinct' => false,
-            'sortFieldWhitelist' => array('a.f', 'a.d')
+            PaginatorInterface::PAGE_PARAMETER_NAME => 'p',
+            PaginatorInterface::SORT_FIELD_PARAMETER_NAME => 's',
+            PaginatorInterface::SORT_DIRECTION_PARAMETER_NAME => 'd',
+            PaginatorInterface::DISTINCT => false,
+            PaginatorInterface::SORT_FIELD_WHITELIST => array('a.f', 'a.d')
         );
 
         $view = $p->paginate($items, 1, 10, $options);
 
-        $this->assertEquals('p', $view->getPaginatorOption('pageParameterName'));
-        $this->assertEquals('s', $view->getPaginatorOption('sortFieldParameterName'));
-        $this->assertEquals('d', $view->getPaginatorOption('sortDirectionParameterName'));
-        $this->assertFalse($view->getPaginatorOption('distinct'));
-        $this->assertEquals(array('a.f', 'a.d'), $view->getPaginatorOption('sortFieldWhitelist'));
+        $this->assertEquals('p', $view->getPaginatorOption(PaginatorInterface::PAGE_PARAMETER_NAME));
+        $this->assertEquals('s', $view->getPaginatorOption(PaginatorInterface::SORT_FIELD_PARAMETER_NAME));
+        $this->assertEquals('d', $view->getPaginatorOption(PaginatorInterface::SORT_DIRECTION_PARAMETER_NAME));
+        $this->assertFalse($view->getPaginatorOption(PaginatorInterface::DISTINCT));
+        $this->assertEquals(array('a.f', 'a.d'), $view->getPaginatorOption(PaginatorInterface::SORT_FIELD_WHITELIST));
 
         // change default paginator options
         $p->setDefaultPaginatorOptions(array(
-            'pageParameterName' => 'pg',
-            'sortFieldParameterName' => 'srt',
-            'sortDirectionParameterName' => 'dir'
+            PaginatorInterface::PAGE_PARAMETER_NAME => 'pg',
+            PaginatorInterface::SORT_FIELD_PARAMETER_NAME => 'srt',
+            PaginatorInterface::SORT_DIRECTION_PARAMETER_NAME => 'dir'
         ));
         $view = $p->paginate($items, 1, 10);
 
-        $this->assertEquals('pg', $view->getPaginatorOption('pageParameterName'));
-        $this->assertEquals('srt', $view->getPaginatorOption('sortFieldParameterName'));
-        $this->assertEquals('dir', $view->getPaginatorOption('sortDirectionParameterName'));
-        $this->assertTrue($view->getPaginatorOption('distinct'));
+        $this->assertEquals('pg', $view->getPaginatorOption(PaginatorInterface::PAGE_PARAMETER_NAME));
+        $this->assertEquals('srt', $view->getPaginatorOption(PaginatorInterface::SORT_FIELD_PARAMETER_NAME));
+        $this->assertEquals('dir', $view->getPaginatorOption(PaginatorInterface::SORT_DIRECTION_PARAMETER_NAME));
+        $this->assertTrue($view->getPaginatorOption(PaginatorInterface::DISTINCT));
     }
 }

--- a/tests/Test/Pager/Subscriber/Filtration/Doctrine/ORM/QueryTest.php
+++ b/tests/Test/Pager/Subscriber/Filtration/Doctrine/ORM/QueryTest.php
@@ -10,6 +10,7 @@ use Knp\Component\Pager\Event\Subscriber\Paginate\PaginationSubscriber;
 use Knp\Component\Pager\Event\Subscriber\Filtration\FiltrationSubscriber as Filtration;
 use Test\Fixture\Entity\Article;
 use Knp\Component\Pager\Event\Subscriber\Paginate\Doctrine\ORM\QuerySubscriber\UsesPaginator;
+use Knp\Component\Pager\PaginatorInterface;
 
 class QueryTest extends BaseTestCaseORM
 {
@@ -468,7 +469,7 @@ ___SQL;
         $dispatcher->addSubscriber(new Filtration());
         $p = new Paginator($dispatcher);
         $this->startQueryLog();
-        $view = $p->paginate($query, 1, 10, array('distinct' => false));
+        $view = $p->paginate($query, 1, 10, array(PaginatorInterface::DISTINCT => false));
         $items = $view->getItems();
         $this->assertEquals(2, count($items));
         $this->assertEquals('summer', $items[0][0]->getTitle());
@@ -555,17 +556,17 @@ ___SQL;
         $query = $this->em->createQuery('SELECT a FROM Test\Fixture\Entity\Article a');
         $query->setHint(UsesPaginator::HINT_FETCH_JOIN_COLLECTION, false);
         $defaultFilterFields = 'a.title';
-        $view = $p->paginate($query, 1, 10, compact('defaultFilterFields'));
+        $view = $p->paginate($query, 1, 10, compact(PaginatorInterface::DEFAULT_FILTER_FIELDS));
         $items = $view->getItems();
         $this->assertEquals(1, count($items));
         $this->assertEquals('summer', $items[0]->getTitle());
         $defaultFilterFields = 'a.id,a.title';
-        $view = $p->paginate($query, 1, 10, compact('defaultFilterFields'));
+        $view = $p->paginate($query, 1, 10, compact(PaginatorInterface::DEFAULT_FILTER_FIELDS));
         $items = $view->getItems();
         $this->assertEquals(1, count($items));
         $this->assertEquals('summer', $items[0]->getTitle());
         $defaultFilterFields = array('a.id', 'a.title');
-        $view = $p->paginate($query, 1, 10, compact('defaultFilterFields'));
+        $view = $p->paginate($query, 1, 10, compact(PaginatorInterface::DEFAULT_FILTER_FIELDS));
         $items = $view->getItems();
         $this->assertEquals(1, count($items));
         $this->assertEquals('summer', $items[0]->getTitle());

--- a/tests/Test/Pager/Subscriber/Filtration/Doctrine/ORM/WhitelistTest.php
+++ b/tests/Test/Pager/Subscriber/Filtration/Doctrine/ORM/WhitelistTest.php
@@ -2,6 +2,7 @@
 
 namespace Test\Pager\Subscriber\Filtration\Doctrine\ORM;
 
+use Knp\Component\Pager\PaginatorInterface;
 use Test\Tool\BaseTestCaseORM;
 use Knp\Component\Pager\Paginator;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -27,14 +28,14 @@ class WhitelistTest extends BaseTestCaseORM
         $dispatcher->addSubscriber(new Filtration());
         $p = new Paginator($dispatcher);
         $filterFieldWhitelist = array('a.title');
-        $view = $p->paginate($query, 1, 10, compact('filterFieldWhitelist'));
+        $view = $p->paginate($query, 1, 10, compact(PaginatorInterface::FILTER_FIELD_WHITELIST));
 
         $items = $view->getItems();
         $this->assertEquals(1, count($items));
         $this->assertEquals('summer', $items[0]->getTitle());
 
         $_GET['filterParam'] = 'a.id';
-        $view = $p->paginate($query, 1, 10, compact('filterFieldWhitelist'));
+        $view = $p->paginate($query, 1, 10, compact(PaginatorInterface::FILTER_FIELD_WHITELIST));
     }
 
     /**

--- a/tests/Test/Pager/Subscriber/Sortable/ArraySubscriberTest.php
+++ b/tests/Test/Pager/Subscriber/Sortable/ArraySubscriberTest.php
@@ -5,6 +5,7 @@ namespace Test\Pager\Subscriber\Sortable;
 use Knp\Component\Pager\Event\ItemsEvent;
 use Knp\Component\Pager\Event\Subscriber\Sortable\ArraySubscriber;
 use Test\Tool\BaseTestCase;
+use Knp\Component\Pager\PaginatorInterface;
 
 class ArraySubscriberTest extends BaseTestCase
 {
@@ -21,7 +22,7 @@ class ArraySubscriberTest extends BaseTestCase
 
         $itemsEvent = new ItemsEvent(0, 10);
         $itemsEvent->target = &$array;
-        $itemsEvent->options = array('sortFieldParameterName' => 'sort', 'sortDirectionParameterName' => 'ord');
+        $itemsEvent->options = array(PaginatorInterface::SORT_FIELD_PARAMETER_NAME => 'sort', PaginatorInterface::SORT_DIRECTION_PARAMETER_NAME => 'ord');
         $_GET = array('sort' => '[entry][sortProperty]', 'ord' => 'asc');
 
         $this->assertEquals(2, $array[0]['entry']['sortProperty']);
@@ -47,8 +48,8 @@ class ArraySubscriberTest extends BaseTestCase
         $itemsEvent = new ItemsEvent(0, 10);
         $itemsEvent->target = &$array;
         $itemsEvent->options = array(
-            'sortFieldParameterName' => 'sort',
-            'sortDirectionParameterName' => 'ord',
+            PaginatorInterface::SORT_FIELD_PARAMETER_NAME => 'sort',
+            PaginatorInterface::SORT_DIRECTION_PARAMETER_NAME => 'ord',
             'sortFunction' => function (&$target, $sortField, $sortDirection) {
                 usort($target, function($object1, $object2) use ($sortField, $sortDirection) {
                     if ($object1[$sortField] == $object2[$sortField]) {

--- a/tests/Test/Pager/Subscriber/Sortable/Doctrine/ODM/MongoDB/WhitelistTest.php
+++ b/tests/Test/Pager/Subscriber/Sortable/Doctrine/ODM/MongoDB/WhitelistTest.php
@@ -2,6 +2,7 @@
 
 namespace Test\Pager\Subscriber\Sortable\Doctrine\ODM\MongoDB;
 
+use Knp\Component\Pager\PaginatorInterface;
 use Test\Tool\BaseTestCaseMongoODM;
 use Knp\Component\Pager\Paginator;
 use Knp\Component\Pager\Pagination\SlidingPagination;
@@ -29,14 +30,14 @@ class WhitelistTest extends BaseTestCaseMongoODM
 
         $p = new Paginator;
         $sortFieldWhitelist = array('title');
-        $view = $p->paginate($query, 1, 10, compact('sortFieldWhitelist'));
+        $view = $p->paginate($query, 1, 10, compact(PaginatorInterface::SORT_FIELD_WHITELIST));
 
         $items = array_values($view->getItems());
         $this->assertEquals(4, count($items));
         $this->assertEquals('autumn', $items[0]->getTitle());
 
         $_GET['sort'] = 'id';
-        $view = $p->paginate($query, 1, 10, compact('sortFieldWhitelist'));
+        $view = $p->paginate($query, 1, 10, compact(PaginatorInterface::SORT_FIELD_WHITELIST));
     }
 
     /**

--- a/tests/Test/Pager/Subscriber/Sortable/Doctrine/ORM/QueryTest.php
+++ b/tests/Test/Pager/Subscriber/Sortable/Doctrine/ORM/QueryTest.php
@@ -2,6 +2,7 @@
 
 namespace Test\Pager\Subscriber\Sortable\Doctrine\ORM;
 
+use Knp\Component\Pager\PaginatorInterface;
 use Test\Tool\BaseTestCaseORM;
 use Knp\Component\Pager\Paginator;
 use Knp\Component\Pager\Pagination\SlidingPagination;
@@ -142,7 +143,7 @@ ___SQL;
 
         $p = new Paginator;
         $this->startQueryLog();
-        $view = $p->paginate($query, 1, 10, array('distinct' => false));
+        $view = $p->paginate($query, 1, 10, array(PaginatorInterface::DISTINCT => false));
 
         $this->assertEquals(2, $this->queryAnalyzer->getNumExecutedQueries());
         $executed = $this->queryAnalyzer->getExecutedQueries();

--- a/tests/Test/Pager/Subscriber/Sortable/Doctrine/ORM/WhitelistTest.php
+++ b/tests/Test/Pager/Subscriber/Sortable/Doctrine/ORM/WhitelistTest.php
@@ -2,6 +2,7 @@
 
 namespace Test\Pager\Subscriber\Sortable\Doctrine\ORM;
 
+use Knp\Component\Pager\PaginatorInterface;
 use Test\Tool\BaseTestCaseORM;
 use Knp\Component\Pager\Paginator;
 use Knp\Component\Pager\Pagination\SlidingPagination;
@@ -27,14 +28,14 @@ class WhitelistTest extends BaseTestCaseORM
 
         $p = new Paginator;
         $sortFieldWhitelist = array('a.title');
-        $view = $p->paginate($query, 1, 10, compact('sortFieldWhitelist'));
+        $view = $p->paginate($query, 1, 10, compact(PaginatorInterface::SORT_FIELD_WHITELIST));
 
         $items = $view->getItems();
         $this->assertEquals(4, count($items));
         $this->assertEquals('autumn', $items[0]->getTitle());
 
         $_GET['sort'] = 'a.id';
-        $view = $p->paginate($query, 1, 10, compact('sortFieldWhitelist'));
+        $view = $p->paginate($query, 1, 10, compact(PaginatorInterface::SORT_FIELD_WHITELIST));
     }
 
     /**


### PR DESCRIPTION
Replacing magic strings for more safety in both user space code and knp-components code.