### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "doctrine/mongodb-odm": "~1.0@beta",
         "doctrine/phpcr-odm": "~1.2",
         "jackalope/jackalope-doctrine-dbal": "~1.2",
-        "phpunit/phpunit": "~4.2",
+        "phpunit/phpunit": "~4.8.35",
         "ruflin/elastica": "~1.0",
         "symfony/property-access": ">=2.3"
     },

--- a/tests/Test/Pager/Subscriber/Paginate/SolariumQuerySubscriberTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/SolariumQuerySubscriberTest.php
@@ -9,8 +9,9 @@ use Knp\Component\Pager\Event\Subscriber\Paginate\ArraySubscriber;
 use Knp\Component\Pager\Event\Subscriber\Paginate\SolariumQuerySubscriber;
 
 use Test\Mock\PaginationSubscriber as MockPaginationSubscriber;
+use PHPUnit\Framework\TestCase;
 
-class SolariumQuerySubscriberTest extends \PHPUnit_Framework_TestCase
+class SolariumQuerySubscriberTest extends TestCase
 {
     /**
      * @test

--- a/tests/Test/Pager/Subscriber/Sortable/SolariumQuerySubscriberTest.php
+++ b/tests/Test/Pager/Subscriber/Sortable/SolariumQuerySubscriberTest.php
@@ -8,8 +8,9 @@ use Knp\Component\Pager\Pagination\PaginationInterface;
 use Knp\Component\Pager\Event\Subscriber\Sortable\SolariumQuerySubscriber;
 
 use Test\Mock\PaginationSubscriber as MockPaginationSubscriber;
+use PHPUnit\Framework\TestCase;
 
-class SolariumQuerySubscriberTest extends \PHPUnit_Framework_TestCase
+class SolariumQuerySubscriberTest extends TestCase
 {
     /**
      * @test

--- a/tests/Test/Tool/BaseTestCase.php
+++ b/tests/Test/Tool/BaseTestCase.php
@@ -2,12 +2,12 @@
 
 namespace Test\Tool;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Base test case
  */
-abstract class BaseTestCase extends PHPUnit_Framework_TestCase
+abstract class BaseTestCase extends TestCase
 {
     /**
      * {@inheritdoc}

--- a/tests/Test/Tool/BaseTestCaseMongoODM.php
+++ b/tests/Test/Tool/BaseTestCaseMongoODM.php
@@ -7,11 +7,12 @@ use Doctrine\ODM\MongoDB\Mapping\Driver\AnnotationDriver;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\Common\EventManager;
 use Doctrine\MongoDB\Connection;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Base test case contains common mock objects
  */
-abstract class BaseTestCaseMongoODM extends \PHPUnit_Framework_TestCase
+abstract class BaseTestCaseMongoODM extends TestCase
 {
     /**
      * @var DocumentManager

--- a/tests/Test/Tool/BaseTestCaseORM.php
+++ b/tests/Test/Tool/BaseTestCaseORM.php
@@ -9,6 +9,7 @@ use Doctrine\ORM\Mapping\Driver\AnnotationDriver;
 use Doctrine\ORM\EntityManager;
 use Doctrine\Common\EventManager;
 use Doctrine\ORM\Tools\SchemaTool;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Base test case contains common mock objects
@@ -21,7 +22,7 @@ use Doctrine\ORM\Tools\SchemaTool;
  * @link http://www.gediminasm.org
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
-abstract class BaseTestCaseORM extends \PHPUnit_Framework_TestCase
+abstract class BaseTestCaseORM extends TestCase
 {
     /**
      * @var EntityManager

--- a/tests/Test/Tool/BaseTestCasePHPCRODM.php
+++ b/tests/Test/Tool/BaseTestCasePHPCRODM.php
@@ -11,11 +11,12 @@ use Doctrine\MongoDB\Connection;
 use Jackalope\RepositoryFactoryDoctrineDBAL;
 use Jackalope\Session;
 use Jackalope\Transport\DoctrineDBAL\RepositorySchema;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Base test case contains common mock objects
  */
-abstract class BaseTestCasePHPCRODM extends \PHPUnit_Framework_TestCase
+abstract class BaseTestCasePHPCRODM extends TestCase
 {
     /**
      * @var DocumentManager


### PR DESCRIPTION
Use `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase`, while extending our TestCases. This will help us migrate to PHPUnit 6, [that no longer support this snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to update `PHPUnit` to [`~4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that supports this new namespace.