### PR TITLE
Refactoring tests

### DIFF
--- a/tests/Test/Pager/Pagination/SlidingTest.php
+++ b/tests/Test/Pager/Pagination/SlidingTest.php
@@ -101,6 +101,6 @@ class SlidingTest extends BaseTestCase
 
         $view = $p->paginate(range(1, 9), 2, 10);
         $items = $view->getItems();
-        $this->assertTrue(empty($items));
+        $this->assertEmpty($items);
     }
 }

--- a/tests/Test/Pager/Pagination/TraversableItemsTest.php
+++ b/tests/Test/Pager/Pagination/TraversableItemsTest.php
@@ -24,7 +24,7 @@ class TraversableItemsTest extends BaseTestCase
         $this->assertEquals('custom', (string)$view);
 
         $items = $view->getItems();
-        $this->assertTrue($items instanceof \ArrayObject);
+        $this->assertInstanceOf('ArrayObject', $items);
         $i = 21;
         foreach ($view as $item) {
             $this->assertEquals($i++, $item);

--- a/tests/Test/Pager/Subscriber/Filtration/Doctrine/ORM/QueryTest.php
+++ b/tests/Test/Pager/Subscriber/Filtration/Doctrine/ORM/QueryTest.php
@@ -77,14 +77,14 @@ class QueryTest extends BaseTestCaseORM
         $view = $p->paginate($query, 1, 10);
 
         $items = $view->getItems();
-        $this->assertEquals(2, count($items));
+        $this->assertCount(2, $items);
         $this->assertEquals('summer', $items[0]->getTitle());
         $this->assertEquals('winter', $items[1]->getTitle());
 
         $_GET['filterValue'] = 'summer';
         $view = $p->paginate($query, 1, 10);
         $items = $view->getItems();
-        $this->assertEquals(1, count($items));
+        $this->assertCount(1, $items);
         $this->assertEquals('summer', $items[0]->getTitle());
 
         $this->assertEquals(4, $this->queryAnalyzer->getNumExecutedQueries());
@@ -120,7 +120,7 @@ class QueryTest extends BaseTestCaseORM
         $query->setHint(UsesPaginator::HINT_FETCH_JOIN_COLLECTION, false);
         $view = $p->paginate($query, 1, 10);
         $items = $view->getItems();
-        $this->assertEquals(2, count($items));
+        $this->assertCount(2, $items);
         $this->assertEquals('summer', $items[0]->getTitle());
         $this->assertEquals('winter', $items[1]->getTitle());
 
@@ -129,21 +129,21 @@ class QueryTest extends BaseTestCaseORM
         $query->setHint(UsesPaginator::HINT_FETCH_JOIN_COLLECTION, false);
         $view = $p->paginate($query, 1, 10);
         $items = $view->getItems();
-        $this->assertEquals(2, count($items));
+        $this->assertCount(2, $items);
         $this->assertEquals('summer', $items[0]->getTitle());
         $this->assertEquals('winter', $items[1]->getTitle());
 
         $_GET['filterValue'] = '0';
         $view = $p->paginate($query, 1, 10);
         $items = $view->getItems();
-        $this->assertEquals(2, count($items));
+        $this->assertCount(2, $items);
         $this->assertEquals('autumn', $items[0]->getTitle());
         $this->assertEquals('spring', $items[1]->getTitle());
 
         $_GET['filterValue'] = 'false';
         $view = $p->paginate($query, 1, 10);
         $items = $view->getItems();
-        $this->assertEquals(2, count($items));
+        $this->assertCount(2, $items);
         $this->assertEquals('autumn', $items[0]->getTitle());
         $this->assertEquals('spring', $items[1]->getTitle());
 
@@ -184,7 +184,7 @@ class QueryTest extends BaseTestCaseORM
         $query->setHint(UsesPaginator::HINT_FETCH_JOIN_COLLECTION, false);
         $view = $p->paginate($query, 1, 10);
         $items = $view->getItems();
-        $this->assertEquals(4, count($items));
+        $this->assertCount(4, $items);
 
         $this->assertEquals(2, $this->queryAnalyzer->getNumExecutedQueries());
         $executed = $this->queryAnalyzer->getExecutedQueries();
@@ -217,7 +217,7 @@ class QueryTest extends BaseTestCaseORM
         $query->setHint(UsesPaginator::HINT_FETCH_JOIN_COLLECTION, false);
         $view = $p->paginate($query, 1, 10);
         $items = $view->getItems();
-        $this->assertEquals(1, count($items));
+        $this->assertCount(1, $items);
         $this->assertEquals('0', $items[0]->getTitle());
 
         $_GET['filterValue'] = '1';
@@ -225,7 +225,7 @@ class QueryTest extends BaseTestCaseORM
         $query->setHint(UsesPaginator::HINT_FETCH_JOIN_COLLECTION, false);
         $view = $p->paginate($query, 1, 10);
         $items = $view->getItems();
-        $this->assertEquals(1, count($items));
+        $this->assertCount(1, $items);
         $this->assertEquals('1', $items[0]->getTitle());
 
         $this->assertEquals(4, $this->queryAnalyzer->getNumExecutedQueries());
@@ -261,19 +261,19 @@ class QueryTest extends BaseTestCaseORM
         $query->setHint(UsesPaginator::HINT_FETCH_JOIN_COLLECTION, false);
         $view = $p->paginate($query, 1, 10);
         $items = $view->getItems();
-        $this->assertEquals(1, count($items));
+        $this->assertCount(1, $items);
         $this->assertEquals('summer', $items[0]->getTitle());
         $_GET['filterParam'] = 'a.id,a.title';
         $view = $p->paginate($query, 1, 10);
         $items = $view->getItems();
-        $this->assertEquals(1, count($items));
+        $this->assertCount(1, $items);
         $this->assertEquals('summer', $items[0]->getTitle());
         $executed = $this->queryAnalyzer->getExecutedQueries();
         $query = $this->em->createQuery('SELECT a FROM Test\Fixture\Entity\Article a WHERE a.title <> \'\' OR (a.title LIKE \'summer\' OR a.title LIKE \'spring\')');
         $query->setHint(UsesPaginator::HINT_FETCH_JOIN_COLLECTION, false);
         $view = $p->paginate($query, 1, 10);
         $items = $view->getItems();
-        $this->assertEquals(2, count($items));
+        $this->assertCount(2, $items);
         $this->assertEquals('summer', $items[0]->getTitle());
         $this->assertEquals('winter', $items[1]->getTitle());
         $executed = $this->queryAnalyzer->getExecutedQueries();
@@ -281,14 +281,14 @@ class QueryTest extends BaseTestCaseORM
         $query->setHint(UsesPaginator::HINT_FETCH_JOIN_COLLECTION, false);
         $view = $p->paginate($query, 1, 10);
         $items = $view->getItems();
-        $this->assertEquals(2, count($items));
+        $this->assertCount(2, $items);
         $this->assertEquals('summer', $items[0]->getTitle());
         $this->assertEquals('winter', $items[1]->getTitle());
         $executed = $this->queryAnalyzer->getExecutedQueries();
         $_GET['filterParam'] = 'a.title';
         $view = $p->paginate($query, 1, 10);
         $items = $view->getItems();
-        $this->assertEquals(2, count($items));
+        $this->assertCount(2, $items);
         $this->assertEquals('summer', $items[0]->getTitle());
         $this->assertEquals('winter', $items[1]->getTitle());
         $executed = $this->queryAnalyzer->getExecutedQueries();
@@ -329,14 +329,14 @@ class QueryTest extends BaseTestCaseORM
         $query->setHint(UsesPaginator::HINT_FETCH_JOIN_COLLECTION, false);
         $view = $p->paginate($query, 1, 10);
         $items = $view->getItems();
-        $this->assertEquals(2, count($items));
+        $this->assertCount(2, $items);
         $this->assertEquals('summer', $items[0]->getTitle());
         $this->assertEquals('winter', $items[1]->getTitle());
 
         $_GET['filterParam'] = array('a.id', 'a.title');
         $view = $p->paginate($query, 1, 10);
         $items = $view->getItems();
-        $this->assertEquals(2, count($items));
+        $this->assertCount(2, $items);
         $this->assertEquals('summer', $items[0]->getTitle());
         $this->assertEquals('winter', $items[1]->getTitle());
         $executed = $this->queryAnalyzer->getExecutedQueries();
@@ -371,7 +371,7 @@ class QueryTest extends BaseTestCaseORM
         $query->setHint(UsesPaginator::HINT_FETCH_JOIN_COLLECTION, false);
         $view = $p->paginate($query, 1, 10);
         $items = $view->getItems();
-        $this->assertEquals(1, count($items));
+        $this->assertCount(1, $items);
         $this->assertEquals('summer', $items[0]->getTitle());
 
         $executed = $this->queryAnalyzer->getExecutedQueries();
@@ -471,7 +471,7 @@ ___SQL;
         $this->startQueryLog();
         $view = $p->paginate($query, 1, 10, array(PaginatorInterface::DISTINCT => false));
         $items = $view->getItems();
-        $this->assertEquals(2, count($items));
+        $this->assertCount(2, $items);
         $this->assertEquals('summer', $items[0][0]->getTitle());
         $this->assertEquals('winter', $items[1][0]->getTitle());
 
@@ -504,7 +504,7 @@ ___SQL;
         $p = new Paginator();
         $this->startQueryLog();
         $view = $p->paginate($query, 1, 10);
-        $this->assertTrue($view instanceof SlidingPagination);
+        $this->assertInstanceOf('Knp\Component\Pager\Pagination\SlidingPagination', $view);
 
         $this->assertEquals(2, $this->queryAnalyzer->getNumExecutedQueries());
         $executed = $this->queryAnalyzer->getExecutedQueries();
@@ -532,7 +532,7 @@ ___SQL;
         $p = new Paginator();
         $this->startQueryLog();
         $view = $p->paginate($query, 1, 10);
-        $this->assertTrue($view instanceof SlidingPagination);
+        $this->assertInstanceOf('Knp\Component\Pager\Pagination\SlidingPagination', $view);
 
         $this->assertEquals(2, $this->queryAnalyzer->getNumExecutedQueries());
     }
@@ -558,17 +558,17 @@ ___SQL;
         $defaultFilterFields = 'a.title';
         $view = $p->paginate($query, 1, 10, compact(PaginatorInterface::DEFAULT_FILTER_FIELDS));
         $items = $view->getItems();
-        $this->assertEquals(1, count($items));
+        $this->assertCount(1, $items);
         $this->assertEquals('summer', $items[0]->getTitle());
         $defaultFilterFields = 'a.id,a.title';
         $view = $p->paginate($query, 1, 10, compact(PaginatorInterface::DEFAULT_FILTER_FIELDS));
         $items = $view->getItems();
-        $this->assertEquals(1, count($items));
+        $this->assertCount(1, $items);
         $this->assertEquals('summer', $items[0]->getTitle());
         $defaultFilterFields = array('a.id', 'a.title');
         $view = $p->paginate($query, 1, 10, compact(PaginatorInterface::DEFAULT_FILTER_FIELDS));
         $items = $view->getItems();
-        $this->assertEquals(1, count($items));
+        $this->assertCount(1, $items);
         $this->assertEquals('summer', $items[0]->getTitle());
         $executed = $this->queryAnalyzer->getExecutedQueries();
 
@@ -604,17 +604,17 @@ ___SQL;
         $query->setHint(UsesPaginator::HINT_FETCH_JOIN_COLLECTION, false);
         $view = $p->paginate($query, 1, 10);
         $items = $view->getItems();
-        $this->assertEquals(4, count($items));
+        $this->assertCount(4, $items);
         $_GET['filterParam'] = '';
         $_GET['filterValue'] = 'summer';
         $view = $p->paginate($query, 1, 10);
         $items = $view->getItems();
-        $this->assertEquals(4, count($items));
+        $this->assertCount(4, $items);
         $_GET['filterParam'] = '';
         $_GET['filterValue'] = '';
         $view = $p->paginate($query, 1, 10);
         $items = $view->getItems();
-        $this->assertEquals(4, count($items));
+        $this->assertCount(4, $items);
         $executed = $this->queryAnalyzer->getExecutedQueries();
 
         // Different aliases separators according to Doctrine version

--- a/tests/Test/Pager/Subscriber/Filtration/Doctrine/ORM/WhitelistTest.php
+++ b/tests/Test/Pager/Subscriber/Filtration/Doctrine/ORM/WhitelistTest.php
@@ -31,7 +31,7 @@ class WhitelistTest extends BaseTestCaseORM
         $view = $p->paginate($query, 1, 10, compact(PaginatorInterface::FILTER_FIELD_WHITELIST));
 
         $items = $view->getItems();
-        $this->assertEquals(1, count($items));
+        $this->assertCount(1, $items);
         $this->assertEquals('summer', $items[0]->getTitle());
 
         $_GET['filterParam'] = 'a.id';
@@ -61,7 +61,7 @@ class WhitelistTest extends BaseTestCaseORM
         $view = $p->paginate($query, 1, 10);
 
         $items = $view->getItems();
-        $this->assertEquals(0, count($items));
+        $this->assertCount(0, $items);
     }
 
     protected function getUsedEntityFixtures()

--- a/tests/Test/Pager/Subscriber/Paginate/ArrayTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/ArrayTest.php
@@ -23,11 +23,11 @@ class ArrayTest extends BaseTestCase
 
         $items = array('first', 'second');
         $view = $p->paginate($items, 1, 10);
-        $this->assertTrue($view instanceof PaginationInterface);
+        $this->assertInstanceOf('Knp\Component\Pager\Pagination\PaginationInterface', $view);
 
         $this->assertEquals(1, $view->getCurrentPageNumber());
         $this->assertEquals(10, $view->getItemNumberPerPage());
-        $this->assertEquals(2, count($view->getItems()));
+        $this->assertCount(2, $view->getItems());
         $this->assertEquals(2, $view->getTotalItemCount());
     }
 
@@ -46,7 +46,7 @@ class ArrayTest extends BaseTestCase
 
         $this->assertEquals(2, $view->getCurrentPageNumber());
         $this->assertEquals(10, $view->getItemNumberPerPage());
-        $this->assertEquals(10, count($view->getItems()));
+        $this->assertCount(10, $view->getItems());
         $this->assertEquals(21, $view->getTotalItemCount());
     }
 
@@ -58,7 +58,7 @@ class ArrayTest extends BaseTestCase
         $items = array('first', 'second');
         $p = new Paginator;
         $view = $p->paginate($items, 1, 10);
-        $this->assertTrue($view instanceof PaginationInterface);
+        $this->assertInstanceOf('Knp\Component\Pager\Pagination\PaginationInterface', $view);
     }
 
     /**
@@ -70,6 +70,6 @@ class ArrayTest extends BaseTestCase
         $array = new \ArrayObject($items);
         $p = new Paginator;
         $view = $p->paginate($array, 1, 10);
-        $this->assertTrue($view instanceof PaginationInterface);
+        $this->assertInstanceOf('Knp\Component\Pager\Pagination\PaginationInterface', $view);
     }
 }

--- a/tests/Test/Pager/Subscriber/Paginate/Doctrine/CollectionTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/Doctrine/CollectionTest.php
@@ -27,7 +27,7 @@ class CollectionTest extends BaseTestCase
 
         $this->assertEquals(1, $view->getCurrentPageNumber());
         $this->assertEquals(10, $view->getItemNumberPerPage());
-        $this->assertEquals(2, count($view->getItems()));
+        $this->assertCount(2, $view->getItems());
         $this->assertEquals(2, $view->getTotalItemCount());
     }
 
@@ -46,7 +46,7 @@ class CollectionTest extends BaseTestCase
 
         $this->assertEquals(2, $view->getCurrentPageNumber());
         $this->assertEquals(10, $view->getItemNumberPerPage());
-        $this->assertEquals(10, count($view->getItems()));
+        $this->assertCount(10, $view->getItems());
         $this->assertEquals(21, $view->getTotalItemCount());
     }
 
@@ -58,6 +58,6 @@ class CollectionTest extends BaseTestCase
         $items = new ArrayCollection(array('first', 'second'));
         $p = new Paginator;
         $view = $p->paginate($items, 1, 10);
-        $this->assertTrue($view instanceof PaginationInterface);
+        $this->assertInstanceOf('Knp\Component\Pager\Pagination\PaginationInterface', $view);
     }
 }

--- a/tests/Test/Pager/Subscriber/Paginate/Doctrine/DBALQueryBuilderTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/Doctrine/DBALQueryBuilderTest.php
@@ -28,7 +28,7 @@ class DBALQueryBuilderTest extends BaseTestCaseORM
         $this->assertEquals(4, $view->getTotalItemCount());
 
         $items = $view->getItems();
-        $this->assertEquals(2, count($items));
+        $this->assertCount(2, $items);
         $this->assertEquals('summer', $items[0]['title']);
         $this->assertEquals('winter', $items[1]['title']);
     }

--- a/tests/Test/Pager/Subscriber/Paginate/Doctrine/ODM/MongoDB/GridFsTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/Doctrine/ODM/MongoDB/GridFsTest.php
@@ -24,7 +24,7 @@ class GridFsTest extends BaseTestCaseMongoODM
         $view = $p->paginate($query, 1, 10);
 
         $cursor = $query->execute();
-        $this->assertEquals(4, count($view->getItems()));
+        $this->assertCount(4, $view->getItems());
     }
 
     private function populate()

--- a/tests/Test/Pager/Subscriber/Paginate/Doctrine/ODM/MongoDB/QueryBuilderTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/Doctrine/ODM/MongoDB/QueryBuilderTest.php
@@ -25,7 +25,7 @@ class QueryBuilderTest extends BaseTestCaseMongoODM
         $this->assertEquals(4, $pagination->getTotalItemCount());
 
         $items = array_values($pagination->getItems());
-        $this->assertEquals(2, count($items));
+        $this->assertCount(2, $items);
         $this->assertEquals('summer', $items[0]->getTitle());
         $this->assertEquals('winter', $items[1]->getTitle());
     }

--- a/tests/Test/Pager/Subscriber/Paginate/Doctrine/ODM/MongoDB/QueryTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/Doctrine/ODM/MongoDB/QueryTest.php
@@ -28,13 +28,13 @@ class QueryTest extends BaseTestCaseMongoODM
         $query = $qb->getQuery();
         $pagination = $p->paginate($query, 1, 2);
 
-        $this->assertTrue($pagination instanceof SlidingPagination);
+        $this->assertInstanceOf('Knp\Component\Pager\Pagination\SlidingPagination', $pagination);
         $this->assertEquals(1, $pagination->getCurrentPageNumber());
         $this->assertEquals(2, $pagination->getItemNumberPerPage());
         $this->assertEquals(4, $pagination->getTotalItemCount());
 
         $items = array_values($pagination->getItems());
-        $this->assertEquals(2, count($items));
+        $this->assertCount(2, $items);
         $this->assertEquals('summer', $items[0]->getTitle());
         $this->assertEquals('winter', $items[1]->getTitle());
     }
@@ -51,7 +51,7 @@ class QueryTest extends BaseTestCaseMongoODM
         ;
         $p = new Paginator;
         $pagination = $p->paginate($query, 1, 10);
-        $this->assertTrue($pagination instanceof SlidingPagination);
+        $this->assertInstanceOf('Knp\Component\Pager\Pagination\SlidingPagination', $pagination);
     }
 
     private function populate()

--- a/tests/Test/Pager/Subscriber/Paginate/Doctrine/ODM/PHPCR/QueryBuilderSubscriberTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/Doctrine/ODM/PHPCR/QueryBuilderSubscriberTest.php
@@ -26,7 +26,7 @@ class QueryBuilderSubscriberTest extends BaseTestCasePHPCRODM
 
         $items = $pagination->getItems();
 
-        $this->assertEquals(2, count($items));
+        $this->assertCount(2, $items);
         $this->assertEquals('summer', $items->first()->getTitle());
         $this->assertEquals('winter', $items->last()->getTitle());
     }

--- a/tests/Test/Pager/Subscriber/Paginate/Doctrine/ODM/PHPCR/QuerySubscriberTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/Doctrine/ODM/PHPCR/QuerySubscriberTest.php
@@ -28,14 +28,14 @@ class QuerySubscriberTest extends BaseTestCasePHPCRODM
 
         $pagination = $p->paginate($query, 1, 2);
 
-        $this->assertTrue($pagination instanceof SlidingPagination);
+        $this->assertInstanceOf('Knp\Component\Pager\Pagination\SlidingPagination', $pagination);
         $this->assertEquals(1, $pagination->getCurrentPageNumber());
         $this->assertEquals(2, $pagination->getItemNumberPerPage());
         $this->assertEquals(4, $pagination->getTotalItemCount());
 
         $items = $pagination->getItems();
 
-        $this->assertEquals(2, count($items));
+        $this->assertCount(2, $items);
         $this->assertEquals('summer', $items->first()->getTitle());
         $this->assertEquals('winter', $items->last()->getTitle());
     }
@@ -50,7 +50,7 @@ class QuerySubscriberTest extends BaseTestCasePHPCRODM
 
         $p = new Paginator();
         $pagination = $p->paginate($query, 1, 10);
-        $this->assertTrue($pagination instanceof SlidingPagination);
+        $this->assertInstanceOf('Knp\Component\Pager\Pagination\SlidingPagination', $pagination);
     }
 
     private function populate()

--- a/tests/Test/Pager/Subscriber/Paginate/Doctrine/ORM/AdvancedQueryTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/Doctrine/ORM/AdvancedQueryTest.php
@@ -56,7 +56,7 @@ ___SQL;
         $q->setHydrationMode(Query::HYDRATE_ARRAY);
         $p = new Paginator;
         $view = $p->paginate($q, 1, 10, array('wrap-queries' => true));
-        $this->assertEquals(3, count($view));
+        $this->assertCount(3, $view);
     }
 
     /**
@@ -75,7 +75,7 @@ ___SQL;
         $q = $this->em->createQuery($dql);
         $p = new Paginator;
         $view = $p->paginate($q, 1, 10);
-        $this->assertEquals(3, count($view));
+        $this->assertCount(3, $view);
         $items = $view->getItems();
         // and should be hydrated as array
         $this->assertTrue(isset($items[0]['title']));
@@ -119,7 +119,7 @@ ___SQL;
         $q->setHydrationMode(\Doctrine\ORM\Query::HYDRATE_ARRAY);
         $p = new Paginator;
         $view = $p->paginate($q, 1, 10);
-        $this->assertEquals(1, count($view));
+        $this->assertCount(1, $view);
         $items = $view->getItems();
         // and should be hydrated as array
         $this->assertEquals('Starship', $items[0][0]['title']);
@@ -144,7 +144,7 @@ ___SQL;
         $q->setHydrationMode(Query::HYDRATE_ARRAY);
         $p = new Paginator;
         $view = $p->paginate($q, 1, 10, array('wrap-queries' => true));
-        $this->assertEquals(3, count($view));
+        $this->assertCount(3, $view);
     }
 
     protected function getUsedEntityFixtures()

--- a/tests/Test/Pager/Subscriber/Paginate/Doctrine/ORM/CompositeKeyTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/Doctrine/ORM/CompositeKeyTest.php
@@ -32,7 +32,7 @@ class CompositeKeyTest extends BaseTestCaseORM
         $view = $p->paginate($query, 1, 10, array('wrap-queries' => true));
 
         $items = $view->getItems();
-        $this->assertEquals(4, count($items));
+        $this->assertCount(4, $items);
     }
 
     protected function getUsedEntityFixtures()

--- a/tests/Test/Pager/Subscriber/Paginate/Doctrine/ORM/QueryBuilderTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/Doctrine/ORM/QueryBuilderTest.php
@@ -28,7 +28,7 @@ class QueryBuilderTest extends BaseTestCaseORM
         $this->assertEquals(4, $view->getTotalItemCount());
 
         $items = $view->getItems();
-        $this->assertEquals(2, count($items));
+        $this->assertCount(2, $items);
         $this->assertEquals('summer', $items[0]->getTitle());
         $this->assertEquals('winter', $items[1]->getTitle());
     }

--- a/tests/Test/Pager/Subscriber/Paginate/Doctrine/ORM/QueryTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/Doctrine/ORM/QueryTest.php
@@ -28,13 +28,13 @@ class QueryTest extends BaseTestCaseORM
         $query = $this->em->createQuery('SELECT a FROM Test\Fixture\Entity\Article a');
         $view = $p->paginate($query, 1, 2);
 
-        $this->assertTrue($view instanceof PaginationInterface);
+        $this->assertInstanceOf('Knp\Component\Pager\Pagination\PaginationInterface', $view);
         $this->assertEquals(1, $view->getCurrentPageNumber());
         $this->assertEquals(2, $view->getItemNumberPerPage());
         $this->assertEquals(4, $view->getTotalItemCount());
 
         $items = $view->getItems();
-        $this->assertEquals(2, count($items));
+        $this->assertCount(2, $items);
         $this->assertEquals('summer', $items[0]->getTitle());
         $this->assertEquals('winter', $items[1]->getTitle());
     }
@@ -50,7 +50,7 @@ class QueryTest extends BaseTestCaseORM
         ;
         $p = new Paginator;
         $view = $p->paginate($query, 1, 10);
-        $this->assertTrue($view instanceof PaginationInterface);
+        $this->assertInstanceOf('Knp\Component\Pager\Pagination\PaginationInterface', $view);
     }
 
     protected function getUsedEntityFixtures()

--- a/tests/Test/Pager/Subscriber/Paginate/Doctrine/ORM/QueryTest/UsesPaginatorTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/Doctrine/ORM/QueryTest/UsesPaginatorTest.php
@@ -37,7 +37,7 @@ ___SQL;
         $p = new Paginator;
         $view = $p->paginate($q, 1, 10, array('wrap-queries' => true));
         $this->assertEquals(3, $this->queryAnalyzer->getNumExecutedQueries());
-        $this->assertEquals(3, count($view));
+        $this->assertCount(3, $view);
     }
 
     /**
@@ -59,7 +59,7 @@ ___SQL;
         $p = new Paginator;
         $view = $p->paginate($q, 1, 10, array('wrap-queries' => false));
         $this->assertEquals(2, $this->queryAnalyzer->getNumExecutedQueries());
-        $this->assertEquals(3, count($view));
+        $this->assertCount(3, $view);
     }
 
     /**
@@ -83,7 +83,7 @@ ___SQL;
         $p = new Paginator;
         $view = $p->paginate($q, 1, 10, array('wrap-queries' => true));
         $this->assertEquals(3, $this->queryAnalyzer->getNumExecutedQueries());
-        $this->assertEquals(3, count($view));
+        $this->assertCount(3, $view);
     }
 
     protected function getUsedEntityFixtures()

--- a/tests/Test/Pager/Subscriber/Paginate/ElasticaTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/ElasticaTest.php
@@ -43,7 +43,7 @@ class ElasticaTest extends BaseTestCase
 
         $this->assertEquals(1, $view->getCurrentPageNumber());
         $this->assertEquals(10, $view->getItemNumberPerPage());
-        $this->assertEquals(2, count($view->getItems()));
+        $this->assertCount(2, $view->getItems());
         $this->assertEquals(2, $view->getTotalItemCount());
     }
 
@@ -62,7 +62,7 @@ class ElasticaTest extends BaseTestCase
 
         $this->assertEquals(2, $view->getCurrentPageNumber());
         $this->assertEquals(10, $view->getItemNumberPerPage());
-        $this->assertEquals(10, count($view->getItems()));
+        $this->assertCount(10, $view->getItems());
         $this->assertEquals(21, $view->getTotalItemCount());*/
     }
 }

--- a/tests/Test/Pager/Subscriber/Sortable/Doctrine/ODM/MongoDB/QueryTest.php
+++ b/tests/Test/Pager/Subscriber/Sortable/Doctrine/ODM/MongoDB/QueryTest.php
@@ -32,7 +32,7 @@ class QueryTest extends BaseTestCaseMongoODM
         $view = $p->paginate($query, 1, 10);
 
         $items = array_values($view->getItems());
-        $this->assertEquals(4, count($items));
+        $this->assertCount(4, $items);
         $this->assertEquals('autumn', $items[0]->getTitle());
         $this->assertEquals('spring', $items[1]->getTitle());
         $this->assertEquals('summer', $items[2]->getTitle());
@@ -41,7 +41,7 @@ class QueryTest extends BaseTestCaseMongoODM
         $_GET['direction'] = 'desc';
         $view = $p->paginate($query, 1, 10);
         $items = array_values($view->getItems());
-        $this->assertEquals(4, count($items));
+        $this->assertCount(4, $items);
         $this->assertEquals('winter', $items[0]->getTitle());
         $this->assertEquals('summer', $items[1]->getTitle());
         $this->assertEquals('spring', $items[2]->getTitle());

--- a/tests/Test/Pager/Subscriber/Sortable/Doctrine/ODM/MongoDB/WhitelistTest.php
+++ b/tests/Test/Pager/Subscriber/Sortable/Doctrine/ODM/MongoDB/WhitelistTest.php
@@ -33,7 +33,7 @@ class WhitelistTest extends BaseTestCaseMongoODM
         $view = $p->paginate($query, 1, 10, compact(PaginatorInterface::SORT_FIELD_WHITELIST));
 
         $items = array_values($view->getItems());
-        $this->assertEquals(4, count($items));
+        $this->assertCount(4, $items);
         $this->assertEquals('autumn', $items[0]->getTitle());
 
         $_GET['sort'] = 'id';

--- a/tests/Test/Pager/Subscriber/Sortable/Doctrine/ORM/QueryTest.php
+++ b/tests/Test/Pager/Subscriber/Sortable/Doctrine/ORM/QueryTest.php
@@ -79,7 +79,7 @@ class QueryTest extends BaseTestCaseORM
         $view = $p->paginate($query, 1, 10);
 
         $items = $view->getItems();
-        $this->assertEquals(4, count($items));
+        $this->assertCount(4, $items);
         $this->assertEquals('autumn', $items[0]->getTitle());
         $this->assertEquals('spring', $items[1]->getTitle());
         $this->assertEquals('summer', $items[2]->getTitle());
@@ -88,7 +88,7 @@ class QueryTest extends BaseTestCaseORM
         $_GET['direction'] = 'desc';
         $view = $p->paginate($query, 1, 10);
         $items = $view->getItems();
-        $this->assertEquals(4, count($items));
+        $this->assertCount(4, $items);
         $this->assertEquals('winter', $items[0]->getTitle());
         $this->assertEquals('summer', $items[1]->getTitle());
         $this->assertEquals('spring', $items[2]->getTitle());
@@ -174,7 +174,7 @@ ___SQL;
         $p = new Paginator;
         $this->startQueryLog();
         $view = $p->paginate($query, 1, 10);
-        $this->assertTrue($view instanceof SlidingPagination);
+        $this->assertInstanceOf('Knp\Component\Pager\Pagination\SlidingPagination', $view);
 
         $this->assertEquals(2, $this->queryAnalyzer->getNumExecutedQueries());
         $executed = $this->queryAnalyzer->getExecutedQueries();
@@ -202,7 +202,7 @@ ___SQL;
         $p = new Paginator;
         $this->startQueryLog();
         $view = $p->paginate($query, 1, 10);
-        $this->assertTrue($view instanceof SlidingPagination);
+        $this->assertInstanceOf('Knp\Component\Pager\Pagination\SlidingPagination', $view);
 
         $this->assertEquals(2, $this->queryAnalyzer->getNumExecutedQueries());
     }

--- a/tests/Test/Pager/Subscriber/Sortable/Doctrine/ORM/WhitelistTest.php
+++ b/tests/Test/Pager/Subscriber/Sortable/Doctrine/ORM/WhitelistTest.php
@@ -31,7 +31,7 @@ class WhitelistTest extends BaseTestCaseORM
         $view = $p->paginate($query, 1, 10, compact(PaginatorInterface::SORT_FIELD_WHITELIST));
 
         $items = $view->getItems();
-        $this->assertEquals(4, count($items));
+        $this->assertCount(4, $items));
         $this->assertEquals('autumn', $items[0]->getTitle());
 
         $_GET['sort'] = 'a.id';


### PR DESCRIPTION
I've refactored some tests, using:
- `assertCount` instead of `count` function;
- `assertInstanceOf` instead of `instanceof` operator;
- `assertEmpty` instead of `empty` function.