### PR TITLE
Fixed multi sort for ODM

### DIFF
--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/Doctrine/ODM/MongoDB/QuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/Doctrine/ODM/MongoDB/QuerySubscriber.php
@@ -29,8 +29,14 @@ class QuerySubscriber implements EventSubscriberInterface
                 }
                 $queryOptions = $reflectionProperty->getValue($event->target);
 
-                //@todo: seems like does not support multisort ??
-                $queryOptions['sort'] = array($field => $dir);
+                // handle multi sort
+                $sortFields = explode('+', $field);
+                $sortOption = [];
+                foreach ($sortFields as $sortField) {
+                    $sortOption[$sortField] = $dir;
+                }
+
+                $queryOptions['sort'] = $sortOption;
                 $reflectionProperty->setValue($event->target, $queryOptions);
             }
         }

--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/Doctrine/ODM/MongoDB/QuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/Doctrine/ODM/MongoDB/QuerySubscriber.php
@@ -31,7 +31,7 @@ class QuerySubscriber implements EventSubscriberInterface
 
                 // handle multi sort
                 $sortFields = explode('+', $field);
-                $sortOption = [];
+                $sortOption = array();
                 foreach ($sortFields as $sortField) {
                     $sortOption[$sortField] = $dir;
                 }

--- a/tests/Test/Fixture/Document/Article.php
+++ b/tests/Test/Fixture/Document/Article.php
@@ -19,6 +19,16 @@ class Article
      */
     private $title;
 
+    /**
+     * @ODM\Field(type="bool", name="status")
+     */
+    private $status;
+
+    /**
+     * @ODM\Field(type="date", name="created_at")
+     */
+    private $createdAt;
+
     public function getId()
     {
         return $this->id;
@@ -32,5 +42,28 @@ class Article
     public function getTitle()
     {
         return $this->title;
+    }
+
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    public function setStatus($status)
+    {
+        $this->status = $status;
+    }
+
+    /**
+     * @param \DateTime $createdAt
+     */
+    public function setCreatedAt(\DateTime $createdAt)
+    {
+        $this->createdAt = $createdAt;
+    }
+
+    public function getCreatedAt()
+    {
+        return $this->createdAt;
     }
 }

--- a/tests/Test/Pager/Subscriber/Sortable/Doctrine/ODM/MongoDB/QueryTest.php
+++ b/tests/Test/Pager/Subscriber/Sortable/Doctrine/ODM/MongoDB/QueryTest.php
@@ -46,6 +46,15 @@ class QueryTest extends BaseTestCaseMongoODM
         $this->assertEquals('summer', $items[1]->getTitle());
         $this->assertEquals('spring', $items[2]->getTitle());
         $this->assertEquals('autumn', $items[3]->getTitle());
+
+        $_GET['sort'] = 'status+created_at';
+        $view = $p->paginate($query, 1, 10);
+        $items = array_values($view->getItems());
+        $this->assertEquals(4, count($items));
+        $this->assertEquals('autumn', $items[0]->getTitle());
+        $this->assertEquals('summer', $items[1]->getTitle());
+        $this->assertEquals('winter', $items[2]->getTitle());
+        $this->assertEquals('spring', $items[3]->getTitle());
     }
 
     /**
@@ -70,15 +79,23 @@ class QueryTest extends BaseTestCaseMongoODM
         $em = $this->getMockDocumentManager();
         $summer = new Article;
         $summer->setTitle('summer');
+        $summer->setStatus('published');
+        $summer->setCreatedAt(new \DateTime('2016-06-06'));
 
         $winter = new Article;
         $winter->setTitle('winter');
+        $summer->setStatus('draft');
+        $summer->setCreatedAt(new \DateTime('2019-09-09'));
 
         $autumn = new Article;
         $autumn->setTitle('autumn');
+        $summer->setStatus('published');
+        $summer->setCreatedAt(new \DateTime('2018-08-08'));
 
         $spring = new Article;
         $spring->setTitle('spring');
+        $summer->setStatus('draft');
+        $summer->setCreatedAt(new \DateTime('2017-07-07'));
 
         $em->persist($summer);
         $em->persist($winter);


### PR DESCRIPTION
Sorting with `['status+created_at' => 'desc']` does not work with ODM. 
But sorting with `['status' => 'desc', 'created_at' => 'desc']` does work.

My use case was that I needed to sort articles by date desc, but having the published ones first and closed ones after. It works with the changes I made in this `QuerySubscriber.php` file.

