### PR TITLE
Fix sorting bug when no existing class property is specified in query string parameter

### DIFF
--- a/tests/Test/Pager/Subscriber/Sortable/ArraySubscriberTest.php
+++ b/tests/Test/Pager/Subscriber/Sortable/ArraySubscriberTest.php
@@ -7,6 +7,29 @@ use Knp\Component\Pager\Event\Subscriber\Sortable\ArraySubscriber;
 use Test\Tool\BaseTestCase;
 use Knp\Component\Pager\PaginatorInterface;
 
+class TestItem
+{
+    private $sortProperty;
+
+    /**
+     * TestItem constructor.
+     *
+     * @param $sortProperty
+     */
+    public function __construct($sortProperty)
+    {
+        $this->sortProperty = $sortProperty;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getSortProperty()
+    {
+        return $this->sortProperty;
+    }
+}
+
 class ArraySubscriberTest extends BaseTestCase
 {
     /**
@@ -32,6 +55,57 @@ class ArraySubscriberTest extends BaseTestCase
         $_GET ['ord'] = 'desc';
         $arraySubscriber->items($itemsEvent);
         $this->assertEquals(3, $array[0]['entry']['sortProperty']);
+    }
+
+    /**
+     * @test
+     */
+    public function classShouldBeSort()
+    {
+        /** @var TestItem[] $array */
+        $array = array(
+            new TestItem(2),
+            new TestItem(3),
+            new TestItem(1),
+        );
+
+        $itemsEvent = new ItemsEvent(0, 10);
+        $itemsEvent->target = &$array;
+        $itemsEvent->options = array(PaginatorInterface::SORT_FIELD_PARAMETER_NAME => 'sort', PaginatorInterface::SORT_DIRECTION_PARAMETER_NAME => 'ord');
+        $_GET = array('sort' => 'sortProperty', 'ord' => 'asc');
+
+        $this->assertEquals(2, $array[0]->getSortProperty());
+        $arraySubscriber = new ArraySubscriber();
+        $arraySubscriber->items($itemsEvent);
+        $this->assertEquals(1, $array[0]->getSortProperty());
+        $_GET ['ord'] = 'desc';
+        $arraySubscriber->items($itemsEvent);
+        $this->assertEquals(3, $array[0]->getSortProperty());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldRunSortFunctionWithoutException()
+    {
+        /** @var TestItem[] $array */
+        $array = array(
+            new TestItem(2),
+            new TestItem(3),
+            new TestItem(1),
+        );
+
+        $itemsEvent = new ItemsEvent(0, 10);
+        $itemsEvent->target = &$array;
+        $itemsEvent->options = array(PaginatorInterface::SORT_FIELD_PARAMETER_NAME => 'sort', PaginatorInterface::SORT_DIRECTION_PARAMETER_NAME => 'ord');
+        $_GET = array('sort' => 'noExistingProperty', 'ord' => 'asc');
+
+        $this->assertEquals(2, $array[0]->getSortProperty());
+        $arraySubscriber = new ArraySubscriber();
+        $arraySubscriber->items($itemsEvent);
+
+        // Just count. because this sort result of relative order is indeterminate.
+        $this->assertCount(3, $array);
     }
 
     /**


### PR DESCRIPTION
I'm using KnpPaginatorBundle. And I want to sort array of objects.

But in v1.3.5, If user sends bad query string parameter, then the object does not have method to respond, so an `NoSuchPropertyException` exception will be thrown (This problem related #174 and This problem was raised by #159).

Before v1.3.5, if sorting property does not exist, it just ignored.

So I fix this problem.

My solution is below.
Checking property existence using `propertyAccessor::isReadable()`. It is simple.
But there are still problem, because of php5.x `usort()` bug. https://bugs.php.net/bug.php?id=50688

Because `propertyAccessor::isReadable()` throws exception internally, then unfortunately `usort()` crash bacause of it's bug.
The error like this.
```
Warning: usort(): Array was modified by the user comparison function
```

So I separate checking logic according to the version of php.