### PR TITLE
Remove unnecessary suggests that are self-evident

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,14 +32,7 @@
     },
 
     "suggest": {
-        "symfony/property-access": "To allow sorting arrays",
-        "doctrine/orm" : "to allow usage pagination with Doctrine ORM",
-        "doctrine/common" : "to allow usage pagination with Doctrine ArrayCollection",
-        "doctrine/mongodb-odm" : "to allow usage pagination with Doctrine ODM MongoDB",
-        "doctrine/phpcr-odm" : "to allow usage pagination with Doctrine ODM PHPCR",
-        "ruflin/Elastica" : "to allow usage pagination with ElasticSearch Client",
-        "propel/propel1" : "to allow usage pagination with Propel ORM",
-        "solarium/solarium" : "to allow usage pagination with Solarium Client"
+        "symfony/property-access": "To allow sorting arrays"
     },
 
     "extra": {


### PR DESCRIPTION
Hi guys!

I'd just like to remove some noise when installing. All of these suggests are unnecessary: they don't guide you to install another library in order to add a new feature to this library. It's really the *other* direction: you will already have `doctrine/orm` installed, and then you will install this library so that you can paginate it.

Cheers!