### PR TITLE
Fix "A non well formed numeric value encountered"

### DIFF
--- a/src/Knp/Component/Pager/Paginator.php
+++ b/src/Knp/Component/Pager/Paginator.php
@@ -82,6 +82,7 @@ class Paginator implements PaginatorInterface
      */
     public function paginate($target, $page = 1, $limit = 10, array $options = array())
     {
+        $page = (int) $page; 
         $limit = intval(abs($limit));
         if (!$limit) {
             throw new \LogicException("Invalid item per page number, must be a positive number");


### PR DESCRIPTION


Hello,

It's finally time to fix the long lasting issue that is spamming our sentry since year(s) :D 

```
ErrorException
A non well formed numeric value encountered
```

Forcing the cast to int finally fixes this issue that occurs randomly on old browser (maybe caused by bots).

![errorexception__a_non_well_formed_numeric_value_encountered](https://user-images.githubusercontent.com/346010/40227277-536385a0-5a8e-11e8-9dae-895b5917055a.png)
