### PR TITLE
[RFR] be able to sort on NULL relation with PropertyAccessor

### DIFF
--- a/tests/Test/Pager/Subscriber/Sortable/ArraySubscriberTest.php
+++ b/tests/Test/Pager/Subscriber/Sortable/ArraySubscriberTest.php
@@ -82,4 +82,34 @@ class ArraySubscriberTest extends BaseTestCase
         $this->assertEquals('hot', $array[0]['name']);
 
     }
+
+    /**
+     * @test
+     */
+    public function shouldSortEvenWhenTheSortPropertyIsNotAccessible()
+    {
+        $array = array(
+            array('entry' => array('sortProperty' => 2)),
+            array('entry' => array()),
+            array('entry' => array('sortProperty' => 1)),
+        );
+
+        $itemsEvent = new ItemsEvent(0, 10);
+        $itemsEvent->target = &$array;
+        $itemsEvent->options = array(PaginatorInterface::SORT_FIELD_PARAMETER_NAME => 'sort', PaginatorInterface::SORT_DIRECTION_PARAMETER_NAME => 'ord');
+
+        $arraySubscriber = new ArraySubscriber();
+
+        // test asc sort
+        $_GET = array('sort' => '[entry][sortProperty]', 'ord' => 'asc');
+        $arraySubscriber->items($itemsEvent);
+        $this->assertEquals(false, isset($array[0]['entry']['sortProperty']));
+
+        $itemsEvent->unsetCustomPaginationParameter('sorted');
+
+        // test desc sort
+        $_GET ['ord'] = 'desc';
+        $arraySubscriber->items($itemsEvent);
+        $this->assertEquals(2, $array[0]['entry']['sortProperty']);
+    }
 }


### PR DESCRIPTION
This is a fix for https://github.com/KnpLabs/KnpPaginatorBundle/issues/494 (see [this comment](https://github.com/KnpLabs/KnpPaginatorBundle/issues/494#issuecomment-419145778)) to still be able to sort entries when the sort field is on a relation.

This relation can be `null` (because the DB column of the FK is set to `NULL`), so in this case we should still be able to sort items by setting them to the first or the last position (depends on the sort direction).