### PR TITLE
Callback pagination

### DIFF
--- a/doc/pager/intro.md
+++ b/doc/pager/intro.md
@@ -55,7 +55,32 @@ $pagination->renderer = function($data) use ($template) {
 
 echo $pagination;
 
-// or paginate Doctrine ORM query
+```
 
-$pagination = $paginator->paginate($em->createQuery('SELECT a FROM Entity\Article a'), 1, 10);
+### Doctrine query pagination
+
+Easy paginate over Doctrine ORM query:
+
+```php
+$pagination = $paginator->paginate($em->createQuery('SELECT a FROM Entity\Article a'), 1/*page*/, 10/*limit*/);
+```
+
+### Custom data repository pagination
+
+For applications having custom data repositories (like DDD repositories, CQRS read models) you can provide custom
+data rerieval inside callbacks.
+
+```php
+$repository = ...;
+
+$count = function () use ($repository) {
+    // your $repository invocation here
+};
+$items = function ($offset, $limit) use ($repository) {
+    // your $repository invocation here
+};
+$target = CallbackPagination($count, $items);
+$pagination = $paginator->paginate($target, 2/*page*/, 10/*limit*/);
+
+// ...
 ```

--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/Callback/CallbackPagination.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/Callback/CallbackPagination.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Knp\Component\Pager\Event\Subscriber\Paginate\Callback;
+
+class CallbackPagination
+{
+    /**
+     * @var callable
+     */
+    private $count;
+
+    /**
+     * @var callable
+     */
+    private $items;
+
+    /**
+     * @param callable $count
+     * @param callable $items
+     */
+    public function __construct(callable $count, callable $items)
+    {
+        $this->count = $count;
+        $this->items = $items;
+    }
+
+    /**
+     * @return int
+     */
+    public function getPaginationCount(): int
+    {
+        return call_user_func($this->count);
+    }
+
+    /**
+     * @param $offset
+     * @param $limit
+     * @return array
+     */
+    public function getPaginationItems($offset, $limit): array
+    {
+        return call_user_func_array($this->items, array($offset, $limit));
+    }
+}

--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/Callback/CallbackPagination.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/Callback/CallbackPagination.php
@@ -2,6 +2,11 @@
 
 namespace Knp\Component\Pager\Event\Subscriber\Paginate\Callback;
 
+/**
+ * Callback pagination.
+ *
+ * @author Piotr Pelczar <me@athlan.pl>
+ */
 class CallbackPagination
 {
     /**
@@ -24,20 +29,12 @@ class CallbackPagination
         $this->items = $items;
     }
 
-    /**
-     * @return int
-     */
     public function getPaginationCount(): int
     {
         return call_user_func($this->count);
     }
 
-    /**
-     * @param $offset
-     * @param $limit
-     * @return array
-     */
-    public function getPaginationItems($offset, $limit): array
+    public function getPaginationItems(int $offset, int $limit): array
     {
         return call_user_func_array($this->items, array($offset, $limit));
     }

--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/Callback/CallbackPagination.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/Callback/CallbackPagination.php
@@ -36,6 +36,6 @@ class CallbackPagination
 
     public function getPaginationItems(int $offset, int $limit): array
     {
-        return call_user_func_array($this->items, array($offset, $limit));
+        return call_user_func_array($this->items, [$offset, $limit]);
     }
 }

--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/Callback/CallbackSubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/Callback/CallbackSubscriber.php
@@ -6,6 +6,11 @@ namespace Knp\Component\Pager\Event\Subscriber\Paginate\Callback;
 use Knp\Component\Pager\Event\ItemsEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
+/**
+ * Callback pagination.
+ *
+ * @author Piotr Pelczar <me@athlan.pl>
+ */
 class CallbackSubscriber implements EventSubscriberInterface
 {
     public function items(ItemsEvent $event)

--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/Callback/CallbackSubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/Callback/CallbackSubscriber.php
@@ -31,7 +31,7 @@ class CallbackSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return array(
-            'knp_pager.items' => array('items', 0)
+            'knp_pager.items' => ['items', 0]
         );
     }
 }

--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/Callback/CallbackSubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/Callback/CallbackSubscriber.php
@@ -1,0 +1,32 @@
+<?php
+
+
+namespace Knp\Component\Pager\Event\Subscriber\Paginate\Callback;
+
+use Knp\Component\Pager\Event\ItemsEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class CallbackSubscriber implements EventSubscriberInterface
+{
+    public function items(ItemsEvent $event)
+    {
+        if ($event->target instanceof CallbackPagination) {
+            $event->count = $event->target->getPaginationCount();
+            if($event->count > 0) {
+                $event->items = $event->target->getPaginationItems($event->getOffset(), $event->getLimit());
+            }
+            else {
+                $event->items = [];
+            }
+
+            $event->stopPropagation();
+        }
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array(
+            'knp_pager.items' => array('items', 0)
+        );
+    }
+}

--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/Callback/CallbackSubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/Callback/CallbackSubscriber.php
@@ -30,8 +30,8 @@ class CallbackSubscriber implements EventSubscriberInterface
 
     public static function getSubscribedEvents(): array
     {
-        return array(
+        return [
             'knp_pager.items' => ['items', 0]
-        );
+        ];
     }
 }

--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/Callback/CallbackSubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/Callback/CallbackSubscriber.php
@@ -13,7 +13,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class CallbackSubscriber implements EventSubscriberInterface
 {
-    public function items(ItemsEvent $event)
+    public function items(ItemsEvent $event): void
     {
         if ($event->target instanceof CallbackPagination) {
             $event->count = $event->target->getPaginationCount();
@@ -28,7 +28,7 @@ class CallbackSubscriber implements EventSubscriberInterface
         }
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return array(
             'knp_pager.items' => array('items', 0)

--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/PaginationSubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/PaginationSubscriber.php
@@ -31,6 +31,7 @@ class PaginationSubscriber implements EventSubscriberInterface
         $disp = $event->getEventDispatcher();
         // hook all standard subscribers
         $disp->addSubscriber(new ArraySubscriber);
+        $disp->addSubscriber(new Callback\CallbackSubscriber);
         $disp->addSubscriber(new Doctrine\ORM\QueryBuilderSubscriber);
         $disp->addSubscriber(new Doctrine\ORM\QuerySubscriber);
         $disp->addSubscriber(new Doctrine\ODM\MongoDB\QueryBuilderSubscriber);

--- a/tests/Test/Pager/Subscriber/Paginate/Callback/CallbackTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/Callback/CallbackTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use Knp\Component\Pager\Event\Subscriber\Paginate\Callback\CallbackPagination;
+use Knp\Component\Pager\Event\Subscriber\Paginate\Callback\CallbackSubscriber;
+use Test\Tool\BaseTestCase;
+use Knp\Component\Pager\Paginator;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Test\Mock\PaginationSubscriber as MockPaginationSubscriber;
+use Knp\Component\Pager\Pagination\PaginationInterface;
+
+class CallbackTest extends BaseTestCase
+{
+    const ITEMS_PER_PAGE = 10;
+    const TOTAL_NUMBER_OF_ITEMS = 35;
+
+    /**
+     * @test
+     */
+    public function shouldPaginate(): void
+    {
+        $p = $this->givenPaginatorConfigured();
+        $items = $this->givenCallbackPagination();
+        $page = 1;
+
+        $view = $p->paginate($items, $page, self::ITEMS_PER_PAGE);
+        $this->assertInstanceOf(PaginationInterface::class, $view);
+
+        $this->assertEquals($page, $view->getCurrentPageNumber());
+        $this->assertEquals(self::ITEMS_PER_PAGE, $view->getItemNumberPerPage());
+        $this->assertCount(self::ITEMS_PER_PAGE, $view->getItems());
+        $this->assertEquals([1,2,3,4,5,6,7,8,9,10], $view->getItems());
+        $this->assertEquals(self::TOTAL_NUMBER_OF_ITEMS, $view->getTotalItemCount());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSlicePaginate(): void
+    {
+        $p = $this->givenPaginatorConfigured();
+        $items = $this->givenCallbackPagination();
+        $page = 2;
+
+        $view = $p->paginate($items, $page, self::ITEMS_PER_PAGE);
+
+        $this->assertEquals($page, $view->getCurrentPageNumber());
+        $this->assertEquals(self::ITEMS_PER_PAGE, $view->getItemNumberPerPage());
+        $this->assertCount(self::ITEMS_PER_PAGE, $view->getItems());
+        $this->assertEquals([11,12,13,14,15,16,17,18,19,20], $view->getItems());
+        $this->assertEquals(self::TOTAL_NUMBER_OF_ITEMS, $view->getTotalItemCount());
+    }
+
+    private function givenPaginatorConfigured(): Paginator
+    {
+        $dispatcher = new EventDispatcher;
+        $dispatcher->addSubscriber(new CallbackSubscriber);
+        $dispatcher->addSubscriber(new MockPaginationSubscriber); // pagination view
+        return new Paginator($dispatcher);
+    }
+
+    private function givenCallbackPagination(): CallbackPagination
+    {
+        $data = range(1, self::TOTAL_NUMBER_OF_ITEMS);
+
+        $count = function () use ($data) {
+            return count($data);
+        };
+        $items = function ($offset, $limit) use ($data) {
+            return array_slice($data, $offset, $limit);
+        };
+
+        return new CallbackPagination($count, $items);
+    }
+}

--- a/tests/Test/Pager/Subscriber/Paginate/Callback/CallbackTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/Callback/CallbackTest.php
@@ -8,7 +8,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 use Test\Mock\PaginationSubscriber as MockPaginationSubscriber;
 use Knp\Component\Pager\Pagination\PaginationInterface;
 
-class CallbackTest extends BaseTestCase
+final class CallbackTest extends BaseTestCase
 {
     const ITEMS_PER_PAGE = 10;
     const TOTAL_NUMBER_OF_ITEMS = 35;

--- a/tests/Test/Pager/Subscriber/Paginate/PaginationSubscriberTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/PaginationSubscriberTest.php
@@ -13,7 +13,7 @@ class PaginationSubscriberTest extends BaseTestCase
     public function shouldRegisterExpectedSubscribersOnlyOnce(): void
     {
         $dispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMock();
-        $dispatcher->expects($this->exactly(12))->method('addSubscriber');
+        $dispatcher->expects($this->exactly(13))->method('addSubscriber');
 
         $subscriber = new PaginationSubscriber;
 


### PR DESCRIPTION
Since there is [pagination support](https://github.com/KnpLabs/knp-components/tree/master/src/Knp/Component/Pager/Event/Subscriber/Paginate) for:
* Arrays
* Elastica Query
* Proper
* Solarium
* Doctrine

Nowadays hexagonal architectures and Domain-Driven Design becomes more and more popular. This implicates to have some abstraction to repositories of data. It's code quality breach to expose implementation details and have pagination over it.

The proposition is to implement an interface being able to paginate over custom callback functions (one for get count, one for get items by limit/offset).

Note: Please squash merge.



Example usage:

```php
$count = function () {
    // return count from repository
};
$items = function ($offset, $limit) {
    // return data from repository using offet and limit
};
$data = CallbackPagination($count, $items);

// pagination here
$pagination = $p->paginate($data, $page, $itemsPerPage);
```