### PR TITLE
Explicitly add maintainers in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,17 @@ PHPUnit 7 or newer is required.
 To setup and run tests follow these steps:
 
 - go to the root directory of components
-- run: 
+- run:
 
 ```bash
     composer install
     composer test
 ```
+
+## Maintainers
+
+Please read [this post](https://knplabs.com/en/blog/news-for-our-foss-projects-maintenance) first.
+
+This library is maintained by the following people (alphabetically sorted) :
+- @garak
+- @polc


### PR DESCRIPTION
As stated in
https://knplabs.com/en/blog/news-for-our-foss-projects-maintenance ,
we'd like to explicitly indicate who is maintaining the project, as the
KNP Labs organization is looking for maintainers.

Thank you @garak and @polc to have taken care of this project lately, I hope you are okay with these changes!

@l3pp4rd thank you for your work so far, are you still interested to have write access to this repository?