### PR TITLE
Fix sorting with 2 items

### DIFF
--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/SolariumQuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/SolariumQuerySubscriber.php
@@ -32,13 +32,12 @@ class SolariumQuerySubscriber implements EventSubscriberInterface
             return;
         }
 
-        if (is_array($event->target) && 2 == count($event->target)) {
-            $event->setCustomPaginationParameter('sorted', true);
-
+        if (is_array($event->target) && 2 === count($event->target)) {
             $values = array_values($event->target);
             [$client, $query] = $values;
 
             if ($client instanceof \Solarium\Client && $query instanceof \Solarium\QueryType\Select\Query\Query) {
+                $event->setCustomPaginationParameter('sorted', true);
                 if ($this->request->query->has($event->options[PaginatorInterface::SORT_FIELD_PARAMETER_NAME])) {
                     if (isset($event->options[PaginatorInterface::SORT_FIELD_WHITELIST])) {
                         if (!in_array($this->request->query->get($event->options[PaginatorInterface::SORT_FIELD_PARAMETER_NAME]), $event->options[PaginatorInterface::SORT_FIELD_WHITELIST])) {


### PR DESCRIPTION
Fixes https://github.com/KnpLabs/knp-components/issues/225

As pointed out by @johonunu, the `SolariumQuerySubscriber` only checked if the array had 2 items and then it set `$event->setCustomPaginationParameter('sorted', true);` as if it was handled.

This is just moving the `if` statement to the first one.