### PR TITLE
Add Symfony 5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ fancy paginator component
 
 ## Running unit tests
 
-PHPUnit 7 or newer is required.
+PHPUnit 8 or newer is required.
 To setup and run tests follow these steps:
 
 - go to the root directory of components

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     ],
     "require": {
         "php": "^7.2",
-        "symfony/event-dispatcher": "^3.4 || ^4.0",
-        "symfony/http-foundation": "^3.4 || ^4.0"
+        "symfony/event-dispatcher": "^3.4 || ^4.0 || ^5.0",
+        "symfony/http-foundation": "^3.4 || ^4.0 || ^5.0"
     },
     "require-dev": {
         "doctrine/mongodb-odm": "^2.0",
@@ -33,8 +33,8 @@
         "jackalope/jackalope-doctrine-dbal": "^1.2",
         "phpunit/phpunit": "^8.0",
         "ruflin/elastica": "^1.0",
-        "symfony/http-kernel": "^3.4 || ^4.0",
-        "symfony/property-access": "^3.4 || ^4.0"
+        "symfony/http-kernel": "^3.4 || ^4.0 || ^5.0",
+        "symfony/property-access": "^3.4 || ^4.0 || ^5.0"
     },
     "suggest": {
         "doctrine/common": "to allow usage pagination with Doctrine ArrayCollection",


### PR DESCRIPTION
Adds Symfony 5 to the allowed versions of Composer dependencies.

Please note that at the time of submitting this, the `doctrine/mongodb-odm` dependency hasn't added support for Symfony 5 yet.