### PR TITLE
Fix PHP 7.4 ArrayObject BC Break

### DIFF
--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/CollectionSubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/CollectionSubscriber.php
@@ -13,10 +13,10 @@ class CollectionSubscriber implements EventSubscriberInterface
     {
         if ($event->target instanceof Collection) {
             $event->count = $event->target->count();
-            $event->items = new ArrayObject($event->target->slice(
+            $event->items = $event->target->slice(
                 $event->getOffset(),
                 $event->getLimit()
-            ));
+            );
             $event->stopPropagation();
         }
     }

--- a/tests/Test/Pager/Subscriber/Paginate/Doctrine/CollectionTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/Doctrine/CollectionTest.php
@@ -34,6 +34,31 @@ final class CollectionTest extends BaseTestCase
     /**
      * @test
      */
+    public function shouldLoopOverPagination(): void
+    {
+        $dispatcher = new EventDispatcher;
+        $dispatcher->addSubscriber(new CollectionSubscriber);
+        $dispatcher->addSubscriber(new MockPaginationSubscriber); // pagination view
+        $p = new Paginator($dispatcher);
+
+        $items = new ArrayCollection(['first', 'second']);
+        $view = $p->paginate($items, 1, 10);
+
+        $counter = 0;
+
+        foreach ($view as $item) {
+            $this->assertEquals($items[$counter], $item);
+
+            ++$counter;
+        }
+
+        $this->assertEquals(2, $counter);
+    }
+
+
+    /**
+     * @test
+     */
     public function shouldSlicePaginateAnArray(): void
     {
         $dispatcher = new EventDispatcher;


### PR DESCRIPTION
CollectionSubscriber is the only pagination subscriber that uses a Doctrine ArrayCollection as its item store. All other subscribers use plain PHP arrays.

PHP 7.4 has a BC break for how ArrayObjects are handled and now current() no longer returns the current item in the ArrayObject.

This fix changes CollectionSubscriber to use a plain PHP array as its item store and also adds a test to confirm that you can iterate over the CollectionArray using foreach().