### PR TITLE
Fix embeddable filtering

### DIFF
--- a/src/Knp/Component/Pager/Event/Subscriber/Filtration/Doctrine/ORM/Query/WhereWalker.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Filtration/Doctrine/ORM/Query/WhereWalker.php
@@ -48,7 +48,7 @@ class WhereWalker extends TreeWalkerAdapter
         $expressions = [];
         foreach ($columns as $column) {
             $alias = false;
-            $parts = explode('.', $column);
+            $parts = explode('.', $column, 2);
             $field = end($parts);
             if (2 <= count($parts)) {
                 $alias = trim(reset($parts));


### PR DESCRIPTION
Related issue : https://github.com/KnpLabs/KnpPaginatorBundle/issues/631

This fix a bug where embedabble fields were not correctly handled. 

eg: 
``` php
// with $column = 'e.address.alias'
$parts = explode('.', $column); // ['e', 'address', 'society']
$field = end($parts); // expect 'address.society', but get 'society'
```

Bug was already fixed for sorting here : https://github.com/KnpLabs/knp-components/pull/142