### PR TITLE
add an option for replacing invalid/out of range page numbers

### DIFF
--- a/src/Knp/Component/Pager/Exception/PageNumberOutOfRangeException.php
+++ b/src/Knp/Component/Pager/Exception/PageNumberOutOfRangeException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Knp\Component\Pager\Exception;
+
+class PageNumberOutOfRangeException extends \OutOfRangeException
+{
+
+}

--- a/src/Knp/Component/Pager/PaginatorInterface.php
+++ b/src/Knp/Component/Pager/PaginatorInterface.php
@@ -21,6 +21,11 @@ interface PaginatorInterface
     public const FILTER_VALUE_PARAMETER_NAME = 'filterValueParameterName';
     public const FILTER_FIELD_WHITELIST = 'filterFieldWhitelist';
     public const DISTINCT = 'distinct';
+    public const PAGE_OUT_OF_RANGE = 'pageOutOfRange';
+
+    public const PAGE_OUT_OF_RANGE_IGNORE = 'ignore'; // do nothing (default)
+    public const PAGE_OUT_OF_RANGE_FIX = 'fix'; // replace page number out of range with max page
+    public const PAGE_OUT_OF_RANGE_THROW_EXCEPTION = 'throwException'; // throw PageNumberOutOfRangeException
 
     /**
      * Paginates anything (depending on event listeners)

--- a/tests/Test/Pager/Pagination/PreventPageOutOfRangeOptionTest.php
+++ b/tests/Test/Pager/Pagination/PreventPageOutOfRangeOptionTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Test\Pager\Pagination;
+
+use Knp\Component\Pager\Exception\PageNumberOutOfRangeException;
+use Knp\Component\Pager\Paginator;
+use Knp\Component\Pager\PaginatorInterface;
+use Test\Tool\BaseTestCase;
+
+final class PreventPageOutOfRangeOptionTest extends BaseTestCase
+{
+    /**
+     * @test
+     */
+    public function shouldBeAbleToHandleOutOfRangePageNumberAsArgument(): void
+    {
+        $p = new Paginator;
+        $items = \range(1, 23);
+        // "fix" option
+        $view = $p->paginate($items, 10, 10, [PaginatorInterface::PAGE_OUT_OF_RANGE => PaginatorInterface::PAGE_OUT_OF_RANGE_FIX]);
+        $pagination = $view->getPaginationData();
+
+        $this->assertEquals(3, $pagination['last']);
+        $this->assertEquals(3, $pagination['current']);
+        $this->assertEquals(2, $pagination['previous']);
+        $this->assertEquals(3, $pagination['currentItemCount']);
+        $this->assertEquals(21, $pagination['firstItemNumber']);
+        $this->assertEquals(23, $pagination['lastItemNumber']);
+
+        // "throwException" option
+        $this->expectException(PageNumberOutOfRangeException::class);
+        $p->paginate($items, 10, 10, [PaginatorInterface::PAGE_OUT_OF_RANGE => PaginatorInterface::PAGE_OUT_OF_RANGE_THROW_EXCEPTION]);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldBeAbleToHandleOutOfRangePageNumberAsDefaultOption(): void
+    {
+        $p = new Paginator;
+        $items = \range(1, 23);
+        // "fix" option
+        $p->setDefaultPaginatorOptions([
+            PaginatorInterface::PAGE_OUT_OF_RANGE => PaginatorInterface::PAGE_OUT_OF_RANGE_FIX,
+        ]);
+        $view = $p->paginate($items, 10, 10);
+        $pagination = $view->getPaginationData();
+
+        $this->assertEquals(3, $pagination['last']);
+        $this->assertEquals(3, $pagination['current']);
+        $this->assertEquals(2, $pagination['previous']);
+        $this->assertEquals(3, $pagination['currentItemCount']);
+        $this->assertEquals(21, $pagination['firstItemNumber']);
+        $this->assertEquals(23, $pagination['lastItemNumber']);
+
+        // "throwException" option
+        $p->setDefaultPaginatorOptions([
+            PaginatorInterface::PAGE_OUT_OF_RANGE => PaginatorInterface::PAGE_OUT_OF_RANGE_THROW_EXCEPTION,
+        ]);
+        $this->expectException(PageNumberOutOfRangeException::class);
+        $p->paginate($items, 10, 10);
+    }
+}


### PR DESCRIPTION
This PR adds an optional flag to enforce valid page number and limit. Negative page number is replaced with 1; too big page number is replaced with the last page; negative number of items per page is replaced with default.

The functionality is disabled by default.

This feature was requested in `KnpPaginatorBundle` [several](https://github.com/KnpLabs/KnpPaginatorBundle/issues/477) [times](
https://github.com/KnpLabs/KnpPaginatorBundle/issues/393).

Once this is merged I will create wrapper functionality in the bundle.