### PR TITLE
make default limit value to be set in default options

### DIFF
--- a/docs/pager/usage.md
+++ b/docs/pager/usage.md
@@ -45,6 +45,10 @@ foreach ($pagination as $item) {
     //...
     echo TAB.'paginated item: '.$item.EOL;
 }
+
+// limit per page can be omitted, or passed as null. In this case default value will be used.
+// some other options can be passed as the 4th argument (see [Configuration](docs/pager/config.md))
+$pagination = $paginator->paginate($target, 3/*page number*/, null/*default limit per page will be used*/, ['pageParameterName' => 'section']/*options*/);
 ```
 
 ### Rendering pagination

--- a/src/Knp/Component/Pager/Paginator.php
+++ b/src/Knp/Component/Pager/Paginator.php
@@ -41,6 +41,7 @@ class Paginator implements PaginatorInterface
         self::FILTER_VALUE_PARAMETER_NAME => 'filterValue',
         self::DISTINCT => true,
         self::PAGE_OUT_OF_RANGE => self::PAGE_OUT_OF_RANGE_IGNORE,
+        self::DEFAULT_LIMIT => self::DEFAULT_LIMIT_VALUE,
     ];
 
     /**
@@ -96,8 +97,9 @@ class Paginator implements PaginatorInterface
      * @throws PageNumberOutOfRangeException
      * @return PaginationInterface
      */
-    public function paginate($target, int $page = 1, int $limit = 10, array $options = []): PaginationInterface
+    public function paginate($target, int $page = 1, int $limit = null, array $options = []): PaginationInterface
     {
+        $limit = $limit ?? $this->defaultOptions[self::DEFAULT_LIMIT];
         if ($limit <= 0 or $page <= 0) {
             throw new \LogicException("Invalid item per page number. Limit: $limit and Page: $page, must be positive non-zero integers");
         }

--- a/src/Knp/Component/Pager/PaginatorInterface.php
+++ b/src/Knp/Component/Pager/PaginatorInterface.php
@@ -21,10 +21,12 @@ interface PaginatorInterface
     public const FILTER_FIELD_WHITELIST = 'filterFieldWhitelist';
     public const DISTINCT = 'distinct';
     public const PAGE_OUT_OF_RANGE = 'pageOutOfRange';
+    public const DEFAULT_LIMIT = 'defaultLimit';
 
     public const PAGE_OUT_OF_RANGE_IGNORE = 'ignore'; // do nothing (default)
     public const PAGE_OUT_OF_RANGE_FIX = 'fix'; // replace page number out of range with max page
     public const PAGE_OUT_OF_RANGE_THROW_EXCEPTION = 'throwException'; // throw PageNumberOutOfRangeException
+    public const DEFAULT_LIMIT_VALUE = 10;
 
     /**
      * Paginates anything (depending on event listeners)

--- a/tests/Test/Pager/Pagination/DefaultLimitOptionTest.php
+++ b/tests/Test/Pager/Pagination/DefaultLimitOptionTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Test\Pager\Pagination;
+
+use Knp\Component\Pager\Paginator;
+use Knp\Component\Pager\PaginatorInterface;
+use Test\Tool\BaseTestCase;
+
+final class DefaultLimitOptionTest extends BaseTestCase
+{
+    /**
+     * @test
+     */
+    public function shouldBeAbleToHandleNullLimit(): void
+    {
+        $p = new Paginator;
+        $items = \range(1, 23);
+        $view = $p->paginate($items, 2, null, []);
+        $pagination = $view->getPaginationData();
+
+        $this->assertEquals(PaginatorInterface::DEFAULT_LIMIT_VALUE, $pagination['numItemsPerPage']);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldBeAbleToOverwriteDefaultLimit(): void
+    {
+        $p = new Paginator;
+        $items = \range(1, 23);
+        $p->setDefaultPaginatorOptions([PaginatorInterface::DEFAULT_LIMIT => 8]);
+        $view = $p->paginate($items);
+        $pagination = $view->getPaginationData();
+
+        $this->assertEquals(8, $pagination['numItemsPerPage']);
+    }
+}


### PR DESCRIPTION
Addressing the #105 

- Default limit value will be set in $defaultOptions, not hardcoded in function declaration.
- Explicitly passing $limit as an argument will work as previously.
- Passing null and getting default limit will be possible while setting other options, like
 `$paginator->paginate($query, 1, null, [])`;
- Later with a wrapper functionality in the `KnpPaginatorBundle` default limit will be configurable globally, as other default options.