### PR TITLE
Fix PAGE_OUT_OF_RANGE_FIX when is set for empty date.

### DIFF
--- a/src/Knp/Component/Pager/Paginator.php
+++ b/src/Knp/Component/Pager/Paginator.php
@@ -136,7 +136,7 @@ class Paginator implements PaginatorInterface
         }
         if ($page > ceil($itemsEvent->count / $limit)) {
             $pageOutOfRangeOption = $options[self::PAGE_OUT_OF_RANGE] ?? $this->defaultOptions[self::PAGE_OUT_OF_RANGE];
-            if ($pageOutOfRangeOption === self::PAGE_OUT_OF_RANGE_FIX) {
+            if ($pageOutOfRangeOption === self::PAGE_OUT_OF_RANGE_FIX && $itemsEvent->count > 0) {
                 // replace page number out of range with max page
                 return $this->paginate($target, ceil($itemsEvent->count / $limit), $limit, $options);
             }

--- a/tests/Test/Pager/Pagination/PreventPageOutOfRangeOptionTest.php
+++ b/tests/Test/Pager/Pagination/PreventPageOutOfRangeOptionTest.php
@@ -35,6 +35,29 @@ final class PreventPageOutOfRangeOptionTest extends BaseTestCase
     /**
      * @test
      */
+    public function shouldBeAbleToHandleOutOfRangePageNumberAsArgumentWithEmptyList(): void
+    {
+        $p = new Paginator;
+        $items = []; //empty array on fix argument perform again paginate with page = 0.
+        // "fix" option
+        $view = $p->paginate($items, 10, 10, [PaginatorInterface::PAGE_OUT_OF_RANGE => PaginatorInterface::PAGE_OUT_OF_RANGE_FIX]);
+        $pagination = $view->getPaginationData();
+
+        $this->assertEquals(0, $pagination['last']);
+        $this->assertEquals(10, $pagination['current']);
+        $this->assertEquals(9, $pagination['previous']);
+        $this->assertEquals(0, $pagination['currentItemCount']);
+        $this->assertEquals(91, $pagination['firstItemNumber']);
+        $this->assertEquals(90, $pagination['lastItemNumber']);
+
+        // "throwException" option
+        $this->expectException(PageNumberOutOfRangeException::class);
+        $p->paginate($items, 10, 10, [PaginatorInterface::PAGE_OUT_OF_RANGE => PaginatorInterface::PAGE_OUT_OF_RANGE_THROW_EXCEPTION]);
+    }
+
+    /**
+     * @test
+     */
     public function shouldBeAbleToHandleOutOfRangePageNumberAsDefaultOption(): void
     {
         $p = new Paginator;


### PR DESCRIPTION
Hello,

If `$pageOutOfRangeOption === PaginatorInterface::PAGE_OUT_OF_RANGE_FIX` is set as option to paginate, then an exception is thrown `LogicException : Invalid item per page number. Limit: 10 and Page: 0, must be positive non-zero integers` because the above condition perform again `Paginator::paginate` with `int $page = 0`;

If `$items->count` is 0, then result from `ceil` is always 0.

I think it's worth checking how many elements our `$itemsEvent` has in this case.

\cc @garak WDYT ?