### PR TITLE
Add getMaxPageNumber to PageNumberOutOfRangeException

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: php
 
 sudo: false
 
+services:
+    - mongodb
+
 cache:
     directories:
         - $HOME/.composer/cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: php
 
 sudo: false
 
-services:
-    - mongodb
-
 cache:
     directories:
         - $HOME/.composer/cache

--- a/src/Knp/Component/Pager/Exception/PageNumberOutOfRangeException.php
+++ b/src/Knp/Component/Pager/Exception/PageNumberOutOfRangeException.php
@@ -2,7 +2,23 @@
 
 namespace Knp\Component\Pager\Exception;
 
-class PageNumberOutOfRangeException extends \OutOfRangeException
-{
+use OutOfRangeException;
+use Throwable;
 
+class PageNumberOutOfRangeException extends OutOfRangeException
+{
+    /** @var int */
+    private $maxPageNumber;
+
+    public function __construct(?string $message, int $maxPageNumber, ?Throwable $previousException = null)
+    {
+        parent::__construct($message, 0, $previousException);
+
+        $this->maxPageNumber = $maxPageNumber;
+    }
+
+    public function getMaxPageNumber(): int
+    {
+        return $this->maxPageNumber;
+    }
 }

--- a/src/Knp/Component/Pager/Paginator.php
+++ b/src/Knp/Component/Pager/Paginator.php
@@ -140,7 +140,7 @@ class Paginator implements PaginatorInterface
                 // replace page number out of range with max page
                 return $this->paginate($target, ceil($itemsEvent->count / $limit), $limit, $options);
             }
-            if ($pageOutOfRangeOption === self::PAGE_OUT_OF_RANGE_THROW_EXCEPTION) {
+            if ($pageOutOfRangeOption === self::PAGE_OUT_OF_RANGE_THROW_EXCEPTION && $itemsEvent->count > 0) {
                 throw new PageNumberOutOfRangeException(
                     sprintf('Page number: %d is out of range.', $page),
                     ceil($itemsEvent->count / $limit)

--- a/src/Knp/Component/Pager/Paginator.php
+++ b/src/Knp/Component/Pager/Paginator.php
@@ -201,7 +201,7 @@ class Paginator implements PaginatorInterface
      */
     protected function dispatch(string $eventName, Event\Event $event): void
     {
-        if (!\class_exists(LegacyEventDispatcherProxy::class)) {
+        if (\class_exists(BaseEvent::class)) {
             $this->eventDispatcher->dispatch($eventName, $event);
         } else {
             $this->eventDispatcher->dispatch($event, $eventName);

--- a/src/Knp/Component/Pager/Paginator.php
+++ b/src/Knp/Component/Pager/Paginator.php
@@ -140,7 +140,7 @@ class Paginator implements PaginatorInterface
                 // replace page number out of range with max page
                 return $this->paginate($target, ceil($itemsEvent->count / $limit), $limit, $options);
             }
-            if ($pageOutOfRangeOption === self::PAGE_OUT_OF_RANGE_THROW_EXCEPTION && $itemsEvent->count > 0) {
+            if ($pageOutOfRangeOption === self::PAGE_OUT_OF_RANGE_THROW_EXCEPTION && $page > 1) {
                 throw new PageNumberOutOfRangeException(
                     sprintf('Page number: %d is out of range.', $page),
                     ceil($itemsEvent->count / $limit)

--- a/src/Knp/Component/Pager/Paginator.php
+++ b/src/Knp/Component/Pager/Paginator.php
@@ -141,7 +141,10 @@ class Paginator implements PaginatorInterface
                 return $this->paginate($target, ceil($itemsEvent->count / $limit), $limit, $options);
             }
             if ($pageOutOfRangeOption === self::PAGE_OUT_OF_RANGE_THROW_EXCEPTION) {
-                throw new PageNumberOutOfRangeException("Page number: $page is out of range.");
+                throw new PageNumberOutOfRangeException(
+                    sprintf('Page number: %d is out of range.', $page),
+                    ceil($itemsEvent->count / $limit)
+                );
             }
         }
 

--- a/src/Knp/Component/Pager/Paginator.php
+++ b/src/Knp/Component/Pager/Paginator.php
@@ -201,7 +201,7 @@ class Paginator implements PaginatorInterface
      */
     protected function dispatch(string $eventName, Event\Event $event): void
     {
-        if (\class_exists(BaseEvent::class)) {
+        if (!\class_exists(LegacyEventDispatcherProxy::class)) {
             $this->eventDispatcher->dispatch($eventName, $event);
         } else {
             $this->eventDispatcher->dispatch($event, $eventName);

--- a/tests/Test/Pager/Pagination/PreventPageOutOfRangeOptionTest.php
+++ b/tests/Test/Pager/Pagination/PreventPageOutOfRangeOptionTest.php
@@ -98,4 +98,32 @@ final class PreventPageOutOfRangeOptionTest extends BaseTestCase
             $this->assertEquals(3, $exception->getMaxPageNumber());
         }
     }
+
+    /**
+     * @test
+     */
+    public function shouldBeAbleToTreatFirstPageAsValidWithEmptyList(): void
+    {
+        $p = new Paginator;
+        $items = []; //empty array on fix argument perform again paginate with page = 0.
+        // "fix" option
+        $view = $p->paginate($items, 1, 10, [PaginatorInterface::PAGE_OUT_OF_RANGE => PaginatorInterface::PAGE_OUT_OF_RANGE_FIX]);
+        $pagination = $view->getPaginationData();
+
+        $this->assertEquals(0, $pagination['last']);
+        $this->assertEquals(1, $pagination['current']);
+        $this->assertFalse(isset($pagination['previous']));
+        $this->assertEquals(0, $pagination['currentItemCount']);
+        $this->assertEquals(1, $pagination['firstItemNumber']);
+        $this->assertEquals(0, $pagination['lastItemNumber']);
+
+        // "throwException" option
+        $p->paginate($items, 1, 10, [PaginatorInterface::PAGE_OUT_OF_RANGE => PaginatorInterface::PAGE_OUT_OF_RANGE_THROW_EXCEPTION]);
+        $this->assertEquals(0, $pagination['last']);
+        $this->assertEquals(1, $pagination['current']);
+        $this->assertFalse(isset($pagination['previous']));
+        $this->assertEquals(0, $pagination['currentItemCount']);
+        $this->assertEquals(1, $pagination['firstItemNumber']);
+        $this->assertEquals(0, $pagination['lastItemNumber']);
+    }
 }

--- a/tests/Test/Pager/Pagination/PreventPageOutOfRangeOptionTest.php
+++ b/tests/Test/Pager/Pagination/PreventPageOutOfRangeOptionTest.php
@@ -83,4 +83,19 @@ final class PreventPageOutOfRangeOptionTest extends BaseTestCase
         $this->expectException(PageNumberOutOfRangeException::class);
         $p->paginate($items, 10, 10);
     }
+
+    /**
+     * @test
+     */
+    public function shouldBeAbleToGetMaxPageWhenExceptionIsThrown(): void
+    {
+        $p = new Paginator;
+        $items = \range(1, 23);
+
+        try {
+            $p->paginate($items, 10, 10, [PaginatorInterface::PAGE_OUT_OF_RANGE => PaginatorInterface::PAGE_OUT_OF_RANGE_THROW_EXCEPTION]);
+        } catch (PageNumberOutOfRangeException $exception) {
+            $this->assertEquals(3, $exception->getMaxPageNumber());
+        }
+    }
 }


### PR DESCRIPTION
Hello,

When using `page_out_of_range: 'throwException'` you can't figure out which is the last page, so this PR adds method`getMaxPageNumber` to PageNumberOutOfRangeException, so you can redirect to last page if you'll like. 

~~Also trying the fix the deprecation message with `LegacyEventDispatcherProxy` on sf 5.1.~~