### PR TITLE
deprecate not passing EventDispatcher to Paginator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.5.0
+
+*To be released*
+
+* deprecated not passing EventDispathcer to Paginator constructor
+
 ## 2.4.0
 
 *Released at 2020-07-13*

--- a/src/Knp/Component/Pager/Paginator.php
+++ b/src/Knp/Component/Pager/Paginator.php
@@ -61,6 +61,7 @@ class Paginator implements PaginatorInterface
     {
         $this->eventDispatcher = \class_exists(BaseEvent::class) && \class_exists(LegacyEventDispatcherProxy::class) ? LegacyEventDispatcherProxy::decorate($eventDispatcher) : $eventDispatcher;
         if (is_null($this->eventDispatcher)) {
+            trigger_deprecation('knplabs/knp-components', '2.5.0', 'Not passing EventDispacher is deprecated and will no longer be supported in v3.');
             $this->eventDispatcher = new EventDispatcher();
             $this->eventDispatcher->addSubscriber(new PaginationSubscriber);
             $this->eventDispatcher->addSubscriber(new SortableSubscriber);


### PR DESCRIPTION
This deprecation should allow an easier transition to version 3