### PR TITLE
Allow odmOptions to mongodb subscriber

### DIFF
--- a/docs/pager/config.md
+++ b/docs/pager/config.md
@@ -24,7 +24,7 @@ The list of existing options are:
 | filterFieldParameterName   | string         | filterParam   | FiltrationSubscriber                            |
 | filterValueParameterName   | string         | filterValue   | FiltrationSubscriber                            |
 | pageOutOfRange             | string         | ignore        | PaginationSubscriber                            |
-
+| odmQueryOptions            | array          | []            | odm QueryBuilderSubscriber                      |
 
 ## Noticeable behaviors of some options
 

--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/ODM/MongoDB/QueryBuilderSubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/ODM/MongoDB/QueryBuilderSubscriber.php
@@ -12,7 +12,7 @@ class QueryBuilderSubscriber implements EventSubscriberInterface
     {
         if ($event->target instanceof Builder) {
             // change target into query
-            $event->target = $event->target->getQuery();
+            $event->target = $event->target->getQuery($event->options[PaginatorInterface::ODM_QUERY_OPTIONS] ?? []);
         }
     }
 

--- a/src/Knp/Component/Pager/PaginatorInterface.php
+++ b/src/Knp/Component/Pager/PaginatorInterface.php
@@ -22,6 +22,7 @@ interface PaginatorInterface
     public const DISTINCT = 'distinct';
     public const PAGE_OUT_OF_RANGE = 'pageOutOfRange';
     public const DEFAULT_LIMIT = 'defaultLimit';
+    public const ODM_QUERY_OPTIONS = 'odmQueryOptions';
 
     public const PAGE_OUT_OF_RANGE_IGNORE = 'ignore'; // do nothing (default)
     public const PAGE_OUT_OF_RANGE_FIX = 'fix'; // replace page number out of range with max page


### PR DESCRIPTION
For example if you want to take care about collation you need to add a 4th parameter on ->paginate() method like this:

```
return $paginator->paginate($builder, 1, 10, [Paginator::ODM_QUERY_OPTIONS => ['collation' => ['locale' => 'en', 'strength' => 2]]]);
```