### PR TITLE
drop support for Symfony 5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^7.3 || ^8.0",
         "symfony/event-dispatcher-contracts": "^1.1 || ^2.0",
-        "symfony/http-foundation": "^4.4 || ^5.1"
+        "symfony/http-foundation": "^4.4 || ^5.2"
     },
     "require-dev": {
         "ext-pdo_sqlite": "*",
@@ -36,8 +36,8 @@
         "propel/propel1": "^1.7",
         "ruflin/elastica": "^7.0",
         "solarium/solarium": "^6.0",
-        "symfony/http-kernel": "^4.4 || ^5.1",
-        "symfony/property-access": "^4.4 || ^5.1"
+        "symfony/http-kernel": "^4.4 || ^5.2",
+        "symfony/property-access": "^4.4 || ^5.2"
     },
     "suggest": {
         "doctrine/common": "to allow usage pagination with Doctrine ArrayCollection",


### PR DESCRIPTION
Symfony 5.1 is out of support [since last January](https://symfony.com/releases/5.1).
Let's drop it, and support only symfony libraries >= 5.2 in next minor version.