### PR TITLE
Updated conflict of doctrine/dbal to prevent installing v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "symfony/property-access": "to allow sorting arrays"
     },
     "conflict": {
-        "doctrine/dbal": "<3.1"
+        "doctrine/dbal": "<3.1 || >=4.0"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Hi,

I was updating the dependencies in my application and got some errors because `doctrine/dbal` was upgraded (3.8.0 => 4.0.0). The issue in our case was caused by the use of the `resetQueryPart()` method at https://github.com/KnpLabs/knp-components/blob/ac704489426b090ea0e7ff4d1dd06e26baa49ee7/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/DBALQueryBuilderSubscriber.php#L26. By updating the value of the conflicts key in `composer.json` it should prevent updating `doctrine/dbal` to version 4.

This is the link to the upgrade documentation of Doctrine: https://github.com/doctrine/dbal/blob/4.0.x/UPGRADE.md#deprecated-reset-methods-from-querybuilder

I hope this makes sense and helps you (and others).

Thanks in advance :)