### PR TITLE
Drop PHP 8.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,7 @@ jobs:
             matrix:
                 include:
                     - description: 'Lowest'
-                      php: '8.0'
+                      php: '8.1'
                       composer_option: '--prefer-lowest'
                     - description: '8.1'
                       php: '8.1'

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -18,6 +18,7 @@ return (new PhpCsFixer\Config())
         'php_unit_mock_short_will_return' => true,
         'no_extra_blank_lines' => true,
         'no_unused_imports' => true,
+        'nullable_type_declaration_for_default_null_value' => true,
     ])
     ->setFinder($finder)
 ;

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "symfony/event-dispatcher-contracts": "^3.0"
     },
     "require-dev": {

--- a/src/Knp/Component/Pager/ArgumentAccess/RequestArgumentAccess.php
+++ b/src/Knp/Component/Pager/ArgumentAccess/RequestArgumentAccess.php
@@ -7,11 +7,8 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 final class RequestArgumentAccess implements ArgumentAccessInterface
 {
-    private RequestStack $requestStack;
-
-    public function __construct(RequestStack $requestStack)
+    public function __construct(private readonly RequestStack $requestStack)
     {
-        $this->requestStack = $requestStack;
     }
 
     public function has(string $name): bool

--- a/src/Knp/Component/Pager/Event/AfterEvent.php
+++ b/src/Knp/Component/Pager/Event/AfterEvent.php
@@ -10,15 +10,11 @@ use Symfony\Contracts\EventDispatcher\Event;
  */
 final class AfterEvent extends Event
 {
-    /** @var PaginationInterface<int, mixed> */
-    private PaginationInterface $pagination;
-
     /**
-     * @param PaginationInterface<int, mixed> $paginationView
+     * @param PaginationInterface<int, mixed> $pagination
      */
-    public function __construct(PaginationInterface $paginationView)
+    public function __construct(private readonly PaginationInterface $pagination)
     {
-        $this->pagination = $paginationView;
     }
 
     /**

--- a/src/Knp/Component/Pager/Event/BeforeEvent.php
+++ b/src/Knp/Component/Pager/Event/BeforeEvent.php
@@ -13,9 +13,9 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 final class BeforeEvent extends Event
 {
     public function __construct(
-        private EventDispatcherInterface $eventDispatcher,
-        private ArgumentAccessInterface $argumentAccess,
-        private ?Connection $connection = null
+        private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly ArgumentAccessInterface $argumentAccess,
+        private readonly ?Connection $connection = null
     ) {
     }
 

--- a/src/Knp/Component/Pager/Event/ItemsEvent.php
+++ b/src/Knp/Component/Pager/Event/ItemsEvent.php
@@ -29,18 +29,13 @@ final class ItemsEvent extends Event
      */
     public int $count;
 
-    private int $offset;
-    private int $limit;
-
     /**
      * @var array<string, mixed>
      */
     private array $customPaginationParams = [];
 
-    public function __construct(int $offset, int $limit)
+    public function __construct(private readonly int $offset, private readonly int $limit)
     {
-        $this->offset = $offset;
-        $this->limit = $limit;
     }
 
     public function setCustomPaginationParameter(string $name, mixed $value): void

--- a/src/Knp/Component/Pager/Event/Subscriber/Filtration/Doctrine/ORM/QuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Filtration/Doctrine/ORM/QuerySubscriber.php
@@ -13,11 +13,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class QuerySubscriber implements EventSubscriberInterface
 {
-    private ArgumentAccessInterface $argumentAccess;
-
-    public function __construct(ArgumentAccessInterface $argumentAccess)
+    public function __construct(private readonly ArgumentAccessInterface $argumentAccess)
     {
-        $this->argumentAccess = $argumentAccess;
     }
 
     public function items(ItemsEvent $event): void

--- a/src/Knp/Component/Pager/Event/Subscriber/Filtration/PropelQuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Filtration/PropelQuerySubscriber.php
@@ -10,11 +10,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class PropelQuerySubscriber implements EventSubscriberInterface
 {
-    private ArgumentAccessInterface $argumentAccess;
-
-    public function __construct(ArgumentAccessInterface $argumentAccess)
+    public function __construct(private readonly ArgumentAccessInterface $argumentAccess)
     {
-        $this->argumentAccess = $argumentAccess;
     }
 
     public function items(ItemsEvent $event): void

--- a/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/DBALQueryBuilderSubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Paginate/Doctrine/DBALQueryBuilderSubscriber.php
@@ -14,7 +14,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class DBALQueryBuilderSubscriber implements EventSubscriberInterface
 {
-    public function __construct(private Connection $connection)
+    public function __construct(private readonly Connection $connection)
     {
     }
 

--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/ArraySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/ArraySubscriber.php
@@ -23,18 +23,15 @@ class ArraySubscriber implements EventSubscriberInterface
      */
     private string $sortDirection;
 
-    private ?PropertyAccessorInterface $propertyAccessor;
+    private readonly ?PropertyAccessorInterface $propertyAccessor;
 
-    private ArgumentAccessInterface $argumentAccess;
-
-    public function __construct(ArgumentAccessInterface $argumentAccess, PropertyAccessorInterface $accessor = null)
+    public function __construct(private readonly ArgumentAccessInterface $argumentAccess, PropertyAccessorInterface $accessor = null)
     {
         if (!$accessor && class_exists(PropertyAccess::class)) {
             $accessor = PropertyAccess::createPropertyAccessorBuilder()->enableMagicCall()->getPropertyAccessor();
         }
 
         $this->propertyAccessor = $accessor;
-        $this->argumentAccess = $argumentAccess;
     }
 
     public function items(ItemsEvent $event): void

--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/ArraySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/ArraySubscriber.php
@@ -25,7 +25,7 @@ class ArraySubscriber implements EventSubscriberInterface
 
     private readonly ?PropertyAccessorInterface $propertyAccessor;
 
-    public function __construct(private readonly ArgumentAccessInterface $argumentAccess, PropertyAccessorInterface $accessor = null)
+    public function __construct(private readonly ArgumentAccessInterface $argumentAccess, ?PropertyAccessorInterface $accessor = null)
     {
         if (!$accessor && class_exists(PropertyAccess::class)) {
             $accessor = PropertyAccess::createPropertyAccessorBuilder()->enableMagicCall()->getPropertyAccessor();

--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/Doctrine/ODM/MongoDB/QuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/Doctrine/ODM/MongoDB/QuerySubscriber.php
@@ -11,11 +11,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class QuerySubscriber implements EventSubscriberInterface
 {
-    private ArgumentAccessInterface $argumentAccess;
-
-    public function __construct(ArgumentAccessInterface $argumentAccess)
+    public function __construct(private readonly ArgumentAccessInterface $argumentAccess)
     {
-        $this->argumentAccess = $argumentAccess;
     }
 
     public function items(ItemsEvent $event): void

--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/Doctrine/ORM/QuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/Doctrine/ORM/QuerySubscriber.php
@@ -13,11 +13,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class QuerySubscriber implements EventSubscriberInterface
 {
-    private ArgumentAccessInterface $argumentAccess;
-
-    public function __construct(ArgumentAccessInterface $argumentAccess)
+    public function __construct(private readonly ArgumentAccessInterface $argumentAccess)
     {
-        $this->argumentAccess = $argumentAccess;
     }
 
     public function items(ItemsEvent $event): void

--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/ElasticaQuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/ElasticaQuerySubscriber.php
@@ -12,11 +12,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class ElasticaQuerySubscriber implements EventSubscriberInterface
 {
-    private ArgumentAccessInterface $argumentAccess;
-
-    public function __construct(ArgumentAccessInterface $argumentAccess)
+    public function __construct(private readonly ArgumentAccessInterface $argumentAccess)
     {
-        $this->argumentAccess = $argumentAccess;
     }
 
     public function items(ItemsEvent $event): void

--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/PropelQuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/PropelQuerySubscriber.php
@@ -10,11 +10,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class PropelQuerySubscriber implements EventSubscriberInterface
 {
-    private ArgumentAccessInterface $argumentAccess;
-
-    public function __construct(ArgumentAccessInterface $argumentAccess)
+    public function __construct(private readonly ArgumentAccessInterface $argumentAccess)
     {
-        $this->argumentAccess = $argumentAccess;
     }
 
     public function items(ItemsEvent $event): void

--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/SolariumQuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/SolariumQuerySubscriber.php
@@ -15,11 +15,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class SolariumQuerySubscriber implements EventSubscriberInterface
 {
-    private ArgumentAccessInterface $argumentAccess;
-
-    public function __construct(ArgumentAccessInterface $argumentAccess)
+    public function __construct(private readonly ArgumentAccessInterface $argumentAccess)
     {
-        $this->argumentAccess = $argumentAccess;
     }
 
     public function items(ItemsEvent $event): void

--- a/src/Knp/Component/Pager/Exception/PageNumberOutOfRangeException.php
+++ b/src/Knp/Component/Pager/Exception/PageNumberOutOfRangeException.php
@@ -7,13 +7,9 @@ use Throwable;
 
 class PageNumberOutOfRangeException extends OutOfRangeException
 {
-    private int $maxPageNumber;
-
-    public function __construct(?string $message, int $maxPageNumber, ?Throwable $previousException = null)
+    public function __construct(?string $message, private readonly int $maxPageNumber, ?Throwable $previousException = null)
     {
         parent::__construct($message, 0, $previousException);
-
-        $this->maxPageNumber = $maxPageNumber;
     }
 
     public function getMaxPageNumber(): int

--- a/src/Knp/Component/Pager/Pagination/SlidingPagination.php
+++ b/src/Knp/Component/Pager/Pagination/SlidingPagination.php
@@ -42,7 +42,7 @@ final class SlidingPagination extends AbstractPagination implements \Stringable
             $output = call_user_func($this->renderer, $data);
         }
 
-        return $output;
+        return (string) $output;
     }
 
     /**

--- a/src/Knp/Component/Pager/Paginator.php
+++ b/src/Knp/Component/Pager/Paginator.php
@@ -35,9 +35,9 @@ final class Paginator implements PaginatorInterface
     ];
 
     public function __construct(
-        private EventDispatcherInterface $eventDispatcher,
+        private readonly EventDispatcherInterface $eventDispatcher,
         private ArgumentAccessInterface $argumentAccess,
-        private ?Connection $connection = null
+        private readonly ?Connection $connection = null
     ) {
     }
 
@@ -62,7 +62,7 @@ final class Paginator implements PaginatorInterface
             throw PageNumberInvalidException::create($page);
         }
 
-        $limit = $limit ?? (int) $this->defaultOptions[self::DEFAULT_LIMIT];
+        $limit ??= (int) $this->defaultOptions[self::DEFAULT_LIMIT];
         if ($limit <= 0) {
             throw PageLimitInvalidException::create($limit);
         }

--- a/src/Knp/Component/Pager/Paginator.php
+++ b/src/Knp/Component/Pager/Paginator.php
@@ -56,7 +56,7 @@ final class Paginator implements PaginatorInterface
      *
      * @return PaginationInterface<int, mixed>
      */
-    public function paginate($target, int $page = 1, int $limit = null, array $options = []): PaginationInterface
+    public function paginate($target, int $page = 1, ?int $limit = null, array $options = []): PaginationInterface
     {
         if ($page <= 0) {
             throw PageNumberInvalidException::create($page);

--- a/src/Knp/Component/Pager/PaginatorInterface.php
+++ b/src/Knp/Component/Pager/PaginatorInterface.php
@@ -45,5 +45,5 @@ interface PaginatorInterface
      *
      * @return PaginationInterface<int, mixed>
      */
-    public function paginate(mixed $target, int $page = 1, int $limit = null, array $options = []): PaginationInterface;
+    public function paginate(mixed $target, int $page = 1, ?int $limit = null, array $options = []): PaginationInterface;
 }

--- a/tests/Test/Fixture/TestItem.php
+++ b/tests/Test/Fixture/TestItem.php
@@ -4,11 +4,8 @@ namespace Test\Fixture;
 
 class TestItem
 {
-    private int $sortProperty;
-
-    public function __construct(int $sortProperty)
+    public function __construct(private readonly int $sortProperty)
     {
-        $this->sortProperty = $sortProperty;
     }
 
     public function getSortProperty(): int

--- a/tests/Test/Pager/Pagination/SlidingTest.php
+++ b/tests/Test/Pager/Pagination/SlidingTest.php
@@ -16,9 +16,7 @@ final class SlidingTest extends BaseTestCase
         $items = \range(1, 23);
         $view = $p->paginate($items, 1, 10);
 
-        $view->renderer = static function ($data) {
-            return 'custom';
-        };
+        $view->renderer = static fn($data) => 'custom';
         $this->assertEquals('custom', (string) $view);
 
         $pagination = $view->getPaginationData();

--- a/tests/Test/Pager/Pagination/TraversableItemsTest.php
+++ b/tests/Test/Pager/Pagination/TraversableItemsTest.php
@@ -16,9 +16,7 @@ final class TraversableItemsTest extends BaseTestCase
         $items = new \ArrayObject(\range(1, 23));
         $view = $p->paginate($items, 3, 10);
 
-        $view->renderer = static function ($data) {
-            return 'custom';
-        };
+        $view->renderer = static fn($data) => 'custom';
         $this->assertEquals('custom', (string)$view);
 
         $items = $view->getItems();

--- a/tests/Test/Pager/Subscriber/Filtration/Doctrine/ORM/QueryTest.php
+++ b/tests/Test/Pager/Subscriber/Filtration/Doctrine/ORM/QueryTest.php
@@ -42,9 +42,7 @@ final class QueryTest extends BaseTestCaseORM
 
         $connection = DriverManager::getConnection($conn, $config);
         $em = new \Doctrine\ORM\EntityManager($connection, $config);
-        $schema = \array_map(static function (string $class) use ($em) {
-            return $em->getClassMetadata($class);
-        }, $this->getUsedEntityFixtures());
+        $schema = \array_map(static fn(string $class) => $em->getClassMetadata($class), $this->getUsedEntityFixtures());
 
         $schemaTool = new \Doctrine\ORM\Tools\SchemaTool($em);
         $schemaTool->dropSchema([]);

--- a/tests/Test/Pager/Subscriber/Paginate/Callback/CallbackTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/Callback/CallbackTest.php
@@ -65,12 +65,8 @@ final class CallbackTest extends BaseTestCase
     {
         $data = \range(1, self::TOTAL_NUMBER_OF_ITEMS);
 
-        $count = function () use ($data) {
-            return \count($data);
-        };
-        $items = function ($offset, $limit) use ($data) {
-            return \array_slice($data, $offset, $limit);
-        };
+        $count = fn() => \count($data);
+        $items = fn($offset, $limit) => \array_slice($data, $offset, $limit);
 
         return new CallbackPagination($count, $items);
     }

--- a/tests/Test/Pager/Subscriber/Sortable/Doctrine/ORM/QueryTest.php
+++ b/tests/Test/Pager/Subscriber/Sortable/Doctrine/ORM/QueryTest.php
@@ -41,9 +41,7 @@ final class QueryTest extends BaseTestCaseORM
 
         $connection = DriverManager::getConnection($conn, $config);
         $em = new EntityManager($connection, $config);
-        $schema = \array_map(static function ($class) use ($em) {
-            return $em->getClassMetadata($class);
-        }, $this->getUsedEntityFixtures());
+        $schema = \array_map(static fn($class) => $em->getClassMetadata($class), $this->getUsedEntityFixtures());
 
         $schemaTool = new SchemaTool($em);
         $schemaTool->dropSchema([]);

--- a/tests/Test/Pager/Subscriber/Sortable/Doctrine/ORM/QueryTest.php
+++ b/tests/Test/Pager/Subscriber/Sortable/Doctrine/ORM/QueryTest.php
@@ -2,6 +2,7 @@
 
 namespace Test\Pager\Subscriber\Sortable\Doctrine\ORM;
 
+use Composer\InstalledVersions;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\SchemaTool;
@@ -216,7 +217,12 @@ final class QueryTest extends BaseTestCaseORM
      */
     public function shouldNotAcceptArrayParameter(): void
     {
-        $this->expectException(\PHP_VERSION_ID < 80100 ? \TypeError::class : \UnexpectedValueException::class);
+        if (version_compare(InstalledVersions::getVersion('symfony/http-foundation'), '6.0', '<')) {
+            $this->expectException(\TypeError::class);
+        } else {
+            $this->expectException(\UnexpectedValueException::class);
+        }
+
         $query = $this
             ->getMockSqliteEntityManager()
             ->createQuery('SELECT a FROM Test\Fixture\Entity\Article a')

--- a/tests/Test/Tool/BaseTestCaseMongoODM.php
+++ b/tests/Test/Tool/BaseTestCaseMongoODM.php
@@ -49,7 +49,7 @@ abstract class BaseTestCaseMongoODM extends BaseTestCase
         try {
             $this->dm = DocumentManager::create($conn, $config, $evm ?: $this->getEventManager());
             $this->dm->getConnection()->connect();
-        } catch (\MongoException $e) {
+        } catch (\MongoException) {
             $this->markTestSkipped('Doctrine MongoDB ODM failed to connect');
         }
         return $this->dm;

--- a/tests/Test/Tool/BaseTestCaseMongoODM.php
+++ b/tests/Test/Tool/BaseTestCaseMongoODM.php
@@ -41,7 +41,7 @@ abstract class BaseTestCaseMongoODM extends BaseTestCase
      * DocumentManager mock object together with
      * annotation mapping driver and database
      */
-    protected function getMockDocumentManager(EventManager $evm = null): DocumentManager
+    protected function getMockDocumentManager(?EventManager $evm = null): DocumentManager
     {
         $conn = new Connection();
         $config = $this->getMockAnnotatedConfig();
@@ -59,7 +59,7 @@ abstract class BaseTestCaseMongoODM extends BaseTestCase
      * DocumentManager mock object with
      * annotation mapping driver
      */
-    protected function getMockMappedDocumentManager(EventManager $evm = null): DocumentManager
+    protected function getMockMappedDocumentManager(?EventManager $evm = null): DocumentManager
     {
         $conn = $this->createMock(Connection::class);
         $config = $this->getMockAnnotatedConfig();

--- a/tests/Test/Tool/BaseTestCaseORM.php
+++ b/tests/Test/Tool/BaseTestCaseORM.php
@@ -78,9 +78,7 @@ abstract class BaseTestCaseORM extends BaseTestCase
         $connection = DriverManager::getConnection($conn, $config);
         $em = new EntityManager($connection, $config, $evm ?: $this->getEventManager());
 
-        $schema = \array_map(static function ($class) use ($em) {
-            return $em->getClassMetadata($class);
-        }, $this->getUsedEntityFixtures());
+        $schema = \array_map(static fn($class) => $em->getClassMetadata($class), $this->getUsedEntityFixtures());
 
         $schemaTool = new SchemaTool($em);
         $schemaTool->dropSchema([]);

--- a/tests/Test/Tool/BaseTestCasePHPCRODM.php
+++ b/tests/Test/Tool/BaseTestCasePHPCRODM.php
@@ -33,7 +33,7 @@ abstract class BaseTestCasePHPCRODM extends BaseTestCase
         }
     }
 
-    protected function getMockDocumentManager(EventManager $evm = null): DocumentManager
+    protected function getMockDocumentManager(?EventManager $evm = null): DocumentManager
     {
         $config = new \Doctrine\ODM\PHPCR\Configuration();
         $config->setMetadataDriverImpl($this->getMetadataDriverImplementation());

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,13 +2,20 @@
 
 require __DIR__.'/../vendor/autoload.php';
 
-if (class_exists('Doctrine\Common\Annotations\AnnotationReader')) {
+if (class_exists(\Doctrine\Common\Annotations\AnnotationReader::class)) {
     if (method_exists(\Doctrine\Common\Annotations\AnnotationRegistry::class, 'class_exists')) {
         \Doctrine\Common\Annotations\AnnotationRegistry::registerLoader('class_exists');
     }
     $reader = new \Doctrine\Common\Annotations\AnnotationReader();
-    if (class_exists('Doctrine\Common\Cache\ArrayCache')) {
-        $reader = new \Doctrine\Common\Annotations\CachedReader($reader, new \Doctrine\Common\Cache\ArrayCache());
+    if (class_exists(\Doctrine\Common\Cache\ArrayCache::class)) {
+        if (class_exists(\Doctrine\Common\Annotations\CachedReader::class)) {
+            $reader = new \Doctrine\Common\Annotations\CachedReader($reader, new \Doctrine\Common\Cache\ArrayCache());
+        } else {
+            $reader = new \Doctrine\Common\Annotations\PsrCachedReader(
+                $reader,
+                \Doctrine\Common\Cache\Psr6\CacheAdapter::wrap(new \Doctrine\Common\Cache\ArrayCache()),
+            );
+        }
     }
 } else {
     $reader = null;


### PR DESCRIPTION
* drop support for PHP 8.0
* use language features of PHP 8.1
* fix "prefer-lowest" pipeline

[Rector](https://getrector.com/) was used to leverage language features of PHP 8.1.

Testing against PHP 8.4 is not possible yet since [`laminas/laminas-code`](https://github.com/laminas/laminas-code) which seems to be an indirect dependency does not allow PHP 8.4 yet.

Closes #338 