### PR TITLE
Bump PHPUnit version to 10

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -9,9 +9,9 @@ $finder = PhpCsFixer\Finder::create()
 return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)
     ->setRules([
-        '@PHP71Migration:risky' => true,
-        '@PHP73Migration' => true,
-        '@PHPUnit75Migration:risky' => true,
+        '@PHP80Migration:risky' => true,
+        '@PHP81Migration' => true,
+        '@PHPUnit100Migration:risky' => true,
         'array_syntax' => ['syntax' => 'short'],
         'ordered_imports' => true,
         'declare_strict_types' => false,

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ fancy paginator component
 
 ## Running unit tests
 
-PHPUnit 9 or newer is required.
+PHPUnit 10 or 11 is required.
 To setup and run tests follow these steps:
 
 - go to the root directory of components

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "doctrine/orm": "^2.13 || ^3.0",
         "doctrine/phpcr-odm": "^1.8 || ^2.0",
         "jackalope/jackalope-doctrine-dbal": "^1.12 || ^2.0",
-        "phpunit/phpunit": "^9.6",
+        "phpunit/phpunit": "^10.5 || ^11.3",
         "propel/propel1": "^1.7",
         "ruflin/elastica": "^7.0",
         "solarium/solarium": "^6.0",

--- a/tests/Test/Pager/Pagination/AbstractPaginationTest.php
+++ b/tests/Test/Pager/Pagination/AbstractPaginationTest.php
@@ -6,15 +6,14 @@ use Knp\Component\Pager\ArgumentAccess\ArgumentAccessInterface;
 use Knp\Component\Pager\Event\Subscriber\Paginate\ArraySubscriber;
 use Knp\Component\Pager\Paginator;
 use Knp\Component\Pager\PaginatorInterface;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Test\Mock\PaginationSubscriber as MockPaginationSubscriber;
 use Test\Tool\BaseTestCase;
 
 final class AbstractPaginationTest extends BaseTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldCustomizeParameterNames(): void
     {
         $dispatcher = new EventDispatcher;

--- a/tests/Test/Pager/Pagination/CustomParameterTest.php
+++ b/tests/Test/Pager/Pagination/CustomParameterTest.php
@@ -4,6 +4,7 @@ namespace Test\Pager\Pagination;
 
 use Knp\Component\Pager\ArgumentAccess\ArgumentAccessInterface;
 use Knp\Component\Pager\Paginator;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Test\Mock\CustomParameterSubscriber;
 use Test\Mock\PaginationSubscriber as MockPaginationSubscriber;
@@ -11,9 +12,7 @@ use Test\Tool\BaseTestCase;
 
 final class CustomParameterTest extends BaseTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldGiveCustomParametersToPaginationView(): void
     {
         $dispatcher = new EventDispatcher;

--- a/tests/Test/Pager/Pagination/DefaultLimitOptionTest.php
+++ b/tests/Test/Pager/Pagination/DefaultLimitOptionTest.php
@@ -3,13 +3,12 @@
 namespace Test\Pager\Pagination;
 
 use Knp\Component\Pager\PaginatorInterface;
+use PHPUnit\Framework\Attributes\Test;
 use Test\Tool\BaseTestCase;
 
 final class DefaultLimitOptionTest extends BaseTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldBeAbleToHandleNullLimit(): void
     {
         $p = $this->getPaginatorInstance();
@@ -20,9 +19,7 @@ final class DefaultLimitOptionTest extends BaseTestCase
         $this->assertEquals(PaginatorInterface::DEFAULT_LIMIT_VALUE, $pagination['numItemsPerPage']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldBeAbleToOverwriteDefaultLimit(): void
     {
         $p = $this->getPaginatorInstance();

--- a/tests/Test/Pager/Pagination/PaginationInterfaceTest.php
+++ b/tests/Test/Pager/Pagination/PaginationInterfaceTest.php
@@ -3,6 +3,7 @@
 namespace Test\Pager\Pagination;
 
 use Knp\Component\Pager\Pagination\PaginationInterface;
+use PHPUnit\Framework\Attributes\Test;
 use Test\Tool\BaseTestCase;
 
 final class PaginationInterfaceTest extends BaseTestCase
@@ -14,17 +15,13 @@ final class PaginationInterfaceTest extends BaseTestCase
         $this->reflection = new \ReflectionClass(PaginationInterface::class);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldBeCountable(): void
     {
         $this->assertTrue($this->reflection->implementsInterface(\Countable::class));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldBeTraversable(): void
     {
         $this->assertTrue($this->reflection->implementsInterface(\Traversable::class));
@@ -32,9 +29,7 @@ final class PaginationInterfaceTest extends BaseTestCase
         $this->assertFalse($this->reflection->implementsInterface(\IteratorAggregate::class));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldBeArrayAccessible(): void
     {
         $this->assertTrue($this->reflection->implementsInterface(\ArrayAccess::class));

--- a/tests/Test/Pager/Pagination/PaginatorTest.php
+++ b/tests/Test/Pager/Pagination/PaginatorTest.php
@@ -4,13 +4,12 @@ namespace Test\Pager\Pagination;
 
 use Knp\Component\Pager\Exception\PageLimitInvalidException;
 use Knp\Component\Pager\Exception\PageNumberInvalidException;
+use PHPUnit\Framework\Attributes\Test;
 use Test\Tool\BaseTestCase;
 
 final class PaginatorTest extends BaseTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldThrowExceptionIfPageIsInvalid(): void
     {
         $this->expectException(PageNumberInvalidException::class);
@@ -19,9 +18,7 @@ final class PaginatorTest extends BaseTestCase
         $paginator->paginate(['a', 'b'], 0, 10);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldThrowExceptionIfLimitIsInvalid(): void
     {
         $this->expectException(PageLimitInvalidException::class);

--- a/tests/Test/Pager/Pagination/PreventPageOutOfRangeOptionTest.php
+++ b/tests/Test/Pager/Pagination/PreventPageOutOfRangeOptionTest.php
@@ -4,13 +4,12 @@ namespace Test\Pager\Pagination;
 
 use Knp\Component\Pager\Exception\PageNumberOutOfRangeException;
 use Knp\Component\Pager\PaginatorInterface;
+use PHPUnit\Framework\Attributes\Test;
 use Test\Tool\BaseTestCase;
 
 final class PreventPageOutOfRangeOptionTest extends BaseTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldBeAbleToHandleOutOfRangePageNumberAsArgument(): void
     {
         $p = $this->getPaginatorInstance();
@@ -31,9 +30,7 @@ final class PreventPageOutOfRangeOptionTest extends BaseTestCase
         $p->paginate($items, 10, 10, [PaginatorInterface::PAGE_OUT_OF_RANGE => PaginatorInterface::PAGE_OUT_OF_RANGE_THROW_EXCEPTION]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldBeAbleToHandleOutOfRangePageNumberAsArgumentWithEmptyList(): void
     {
         $p = $this->getPaginatorInstance();
@@ -54,9 +51,7 @@ final class PreventPageOutOfRangeOptionTest extends BaseTestCase
         $p->paginate($items, 10, 10, [PaginatorInterface::PAGE_OUT_OF_RANGE => PaginatorInterface::PAGE_OUT_OF_RANGE_THROW_EXCEPTION]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldBeAbleToHandleOutOfRangePageNumberAsDefaultOption(): void
     {
         $p = $this->getPaginatorInstance();
@@ -83,9 +78,7 @@ final class PreventPageOutOfRangeOptionTest extends BaseTestCase
         $p->paginate($items, 10, 10);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldBeAbleToGetMaxPageWhenExceptionIsThrown(): void
     {
         $p = $this->getPaginatorInstance();
@@ -98,9 +91,7 @@ final class PreventPageOutOfRangeOptionTest extends BaseTestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldBeAbleToTreatFirstPageAsValidWithEmptyList(): void
     {
         $p = $this->getPaginatorInstance();

--- a/tests/Test/Pager/Pagination/SlidingTest.php
+++ b/tests/Test/Pager/Pagination/SlidingTest.php
@@ -2,13 +2,12 @@
 
 namespace Test\Pager\Pagination;
 
+use PHPUnit\Framework\Attributes\Test;
 use Test\Tool\BaseTestCase;
 
 final class SlidingTest extends BaseTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldBeAbleToProducePagination(): void
     {
         $p = $this->getPaginatorInstance();
@@ -35,9 +34,7 @@ final class SlidingTest extends BaseTestCase
         $this->assertEquals(10, $pagination['lastItemNumber']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldBeAbleToProduceWiderPagination(): void
     {
         $p = $this->getPaginatorInstance();
@@ -62,9 +59,7 @@ final class SlidingTest extends BaseTestCase
         $this->assertEquals(20, $pagination['lastItemNumber']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldHandleOddAndEvenRange(): void
     {
         $p = $this->getPaginatorInstance();
@@ -88,9 +83,7 @@ final class SlidingTest extends BaseTestCase
         $this->assertEquals(5, $pagination['lastPageInRange']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldNotFallbackToPageInCaseIfExceedsItemLimit(): void
     {
         $p = $this->getPaginatorInstance();

--- a/tests/Test/Pager/Pagination/TraversableItemsTest.php
+++ b/tests/Test/Pager/Pagination/TraversableItemsTest.php
@@ -2,13 +2,12 @@
 
 namespace Test\Pager\Pagination;
 
+use PHPUnit\Framework\Attributes\Test;
 use Test\Tool\BaseTestCase;
 
 final class TraversableItemsTest extends BaseTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldBeAbleToUseTraversableItems(): void
     {
         $p = $this->getPaginatorInstance();

--- a/tests/Test/Pager/PaginatorTest.php
+++ b/tests/Test/Pager/PaginatorTest.php
@@ -3,14 +3,13 @@
 namespace Test\Pager;
 
 use Knp\Component\Pager\Event\Subscriber\Paginate\PaginationSubscriber;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Test\Tool\BaseTestCase;
 
 final class PaginatorTest extends BaseTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldNotBeAbleToPaginateWithoutListeners(): void
     {
         $this->expectException(\RuntimeException::class);
@@ -19,9 +18,7 @@ final class PaginatorTest extends BaseTestCase
         $paginator->paginate([]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFailToPaginateUnsupportedValue(): void
     {
         $this->expectException(\RuntimeException::class);

--- a/tests/Test/Pager/Subscriber/Filtration/Doctrine/ORM/AllowListTest.php
+++ b/tests/Test/Pager/Subscriber/Filtration/Doctrine/ORM/AllowListTest.php
@@ -7,15 +7,14 @@ use Knp\Component\Pager\Event\Subscriber\Filtration\FiltrationSubscriber as Filt
 use Knp\Component\Pager\Event\Subscriber\Paginate\PaginationSubscriber;
 use Knp\Component\Pager\Paginator;
 use Knp\Component\Pager\PaginatorInterface;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Test\Fixture\Entity\Article;
 use Test\Tool\BaseTestCaseORM;
 
 final class AllowListTest extends BaseTestCaseORM
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldAllowListFiltrationFields(): void
     {
         $this->expectException(\UnexpectedValueException::class);
@@ -43,9 +42,7 @@ final class AllowListTest extends BaseTestCaseORM
         $p->paginate($query, 1, 10, \compact(PaginatorInterface::FILTER_FIELD_ALLOW_LIST));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFilterWithoutSpecificAllowList(): void
     {
         $this->populate();
@@ -63,9 +60,7 @@ final class AllowListTest extends BaseTestCaseORM
         self::assertEquals('autumn', $items[0]->getTitle());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFilterWithoutSpecificAllowList2(): void
     {
         $this->populate();

--- a/tests/Test/Pager/Subscriber/Filtration/Doctrine/ORM/QueryTest.php
+++ b/tests/Test/Pager/Subscriber/Filtration/Doctrine/ORM/QueryTest.php
@@ -12,6 +12,7 @@ use Knp\Component\Pager\Event\Subscriber\Paginate\PaginationSubscriber;
 use Knp\Component\Pager\Pagination\SlidingPagination;
 use Knp\Component\Pager\Paginator;
 use Knp\Component\Pager\PaginatorInterface;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Test\Fixture\Entity\Article;
@@ -19,9 +20,7 @@ use Test\Tool\BaseTestCaseORM;
 
 final class QueryTest extends BaseTestCaseORM
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldHandleApcQueryCache(): void
     {
         if (!\extension_loaded('apc') || !\ini_get('apc.enable_cli')) {
@@ -60,9 +59,7 @@ final class QueryTest extends BaseTestCaseORM
         $p->paginate($query, 1, 10);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFilterSimpleDoctrineQuery(): void
     {
         $em = $this->getMockSqliteEntityManager();
@@ -92,9 +89,7 @@ final class QueryTest extends BaseTestCaseORM
         $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1, a0_.enabled AS enabled_2 FROM Article a0_ WHERE a0_.title LIKE \'%er\' LIMIT 10', $executed[1]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFilterSimpleDoctrineQueryWithoutWildcard(): void
     {
         $em = $this->getMockSqliteEntityManager();
@@ -123,9 +118,7 @@ final class QueryTest extends BaseTestCaseORM
         $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1, a0_.enabled AS enabled_2 FROM Article a0_ WHERE a0_.title LIKE \'summer\' LIMIT 10', $executed[1]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFilterBooleanFilterValuesWithInteger(): void
     {
         $em = $this->getMockSqliteEntityManager();
@@ -153,9 +146,7 @@ final class QueryTest extends BaseTestCaseORM
         $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1, a0_.enabled AS enabled_2 FROM Article a0_ WHERE a0_.enabled = 1 LIMIT 10', $executed[1]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFilterBooleanFilterValues(): void
     {
         $em = $this->getMockSqliteEntityManager();
@@ -183,9 +174,7 @@ final class QueryTest extends BaseTestCaseORM
         $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1, a0_.enabled AS enabled_2 FROM Article a0_ WHERE a0_.enabled = 1 LIMIT 10', $executed[1]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFilterBooleanFilterValuesWithZero(): void
     {
         $em = $this->getMockSqliteEntityManager();
@@ -212,9 +201,7 @@ final class QueryTest extends BaseTestCaseORM
         $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1, a0_.enabled AS enabled_2 FROM Article a0_ WHERE a0_.enabled = 0 LIMIT 10', $executed[1]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFilterBooleanFilterValuesFalse(): void
     {
         $em = $this->getMockSqliteEntityManager();
@@ -241,9 +228,7 @@ final class QueryTest extends BaseTestCaseORM
         $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1, a0_.enabled AS enabled_2 FROM Article a0_ WHERE a0_.enabled = 0 LIMIT 10', $executed[1]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldNotFilterInvalidBooleanFilterValues(): void
     {
         $em = $this->getMockSqliteEntityManager();
@@ -269,9 +254,7 @@ final class QueryTest extends BaseTestCaseORM
         $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1, a0_.enabled AS enabled_2 FROM Article a0_ LIMIT 10', $executed[1]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFilterNumericFilterValues(): void
     {
         $em = $this->getMockSqliteEntityManager();
@@ -298,9 +281,7 @@ final class QueryTest extends BaseTestCaseORM
         $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1, a0_.enabled AS enabled_2 FROM Article a0_ WHERE a0_.title LIKE \'0\' LIMIT 10', $executed[1]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFilterNumericFilterValuesOne(): void
     {
         $em = $this->getMockSqliteEntityManager();
@@ -328,9 +309,7 @@ final class QueryTest extends BaseTestCaseORM
         $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1, a0_.enabled AS enabled_2 FROM Article a0_ WHERE a0_.title LIKE \'1\' LIMIT 10', $executed[1]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFilterComplexDoctrineQuery(): void
     {
         $em = $this->getMockSqliteEntityManager();
@@ -356,9 +335,7 @@ final class QueryTest extends BaseTestCaseORM
         $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1, a0_.enabled AS enabled_2 FROM Article a0_ WHERE a0_.title LIKE \'%er\' AND a0_.title <> \'\' AND (a0_.title LIKE \'summer\' OR a0_.title LIKE \'spring\') LIMIT 10', $executed[1]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFilterComplexDoctrineQuery2(): void
     {
         $em = $this->getMockSqliteEntityManager();
@@ -402,9 +379,7 @@ final class QueryTest extends BaseTestCaseORM
         $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1, a0_.enabled AS enabled_2 FROM Article a0_ WHERE (a0_.id LIKE \'%er\' OR a0_.title LIKE \'%er\') AND a0_.title <> \'\' LIMIT 10', $executed[5]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFilterComplexDoctrineQuery3(): void
     {
         $em = $this->getMockSqliteEntityManager();
@@ -431,9 +406,7 @@ final class QueryTest extends BaseTestCaseORM
         $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1, a0_.enabled AS enabled_2 FROM Article a0_ WHERE a0_.title LIKE \'%er\' AND a0_.title <> \'\' LIMIT 10', $executed[1]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFilterSimpleDoctrineQueryWithMultipleProperties(): void
     {
         $em = $this->getMockSqliteEntityManager();
@@ -469,9 +442,7 @@ final class QueryTest extends BaseTestCaseORM
         $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1, a0_.enabled AS enabled_2 FROM Article a0_ WHERE a0_.id LIKE \'%er\' OR a0_.title LIKE \'%er\' LIMIT 10', $executed[3]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFilterComplexDoctrineQueryWithMultipleProperties(): void
     {
         $em = $this->getMockSqliteEntityManager();
@@ -497,9 +468,7 @@ final class QueryTest extends BaseTestCaseORM
         $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1, a0_.enabled AS enabled_2 FROM Article a0_ WHERE (a0_.id LIKE \'%er\' OR a0_.title LIKE \'%er\') AND a0_.title <> \'\' AND (a0_.title LIKE \'summer\' OR a0_.title LIKE \'spring\') LIMIT 10', $executed[1]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldValidateFiltrationParameter(): void
     {
         $this->expectException(\UnexpectedValueException::class);
@@ -519,9 +488,7 @@ final class QueryTest extends BaseTestCaseORM
         $items = $view->getItems();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldValidateFiltrationParameterWithoutAlias(): void
     {
         $this->expectException(\UnexpectedValueException::class);
@@ -541,9 +508,7 @@ final class QueryTest extends BaseTestCaseORM
         $items = $view->getItems();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldValidateFiltrationParameterExistance(): void
     {
         $this->expectException(\UnexpectedValueException::class);
@@ -564,9 +529,7 @@ final class QueryTest extends BaseTestCaseORM
         $items = $view->getItems();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFilterByAnyAvailableAlias(): void
     {
         $em = $this->getMockSqliteEntityManager();
@@ -598,9 +561,7 @@ final class QueryTest extends BaseTestCaseORM
         $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1, a0_.enabled AS enabled_2, a0_.title AS title_3 FROM Article a0_ WHERE a0_.title LIKE \'%er\' LIMIT 10', $executed[1]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldNotWorkWithInitialPaginatorEventDispatcher(): void
     {
         $em = $this->getMockSqliteEntityManager();
@@ -621,9 +582,7 @@ final class QueryTest extends BaseTestCaseORM
         $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1, a0_.enabled AS enabled_2 FROM Article a0_ LIMIT 10', $executed[1]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldNotExecuteExtraQueriesWhenCountIsZero(): void
     {
         $query = $this
@@ -641,9 +600,7 @@ final class QueryTest extends BaseTestCaseORM
         $this->assertEquals(2, $this->queryAnalyzer->getNumExecutedQueries());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFilterWithEmptyParametersAndDefaults(): void
     {
         $em = $this->getMockSqliteEntityManager();
@@ -681,9 +638,7 @@ final class QueryTest extends BaseTestCaseORM
         $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1, a0_.enabled AS enabled_2 FROM Article a0_ WHERE a0_.id LIKE \'summer\' OR a0_.title LIKE \'summer\' LIMIT 10', $executed[5]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldNotFilterWithEmptyParametersAndDefaults(): void
     {
         $em = $this->getMockSqliteEntityManager();
@@ -723,9 +678,7 @@ final class QueryTest extends BaseTestCaseORM
         $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1, a0_.enabled AS enabled_2 FROM Article a0_ LIMIT 10', $executed[5]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFilterCaseInsensitiveWhenAsked(): void
     {
         $em = $this->getMockSqliteEntityManager();

--- a/tests/Test/Pager/Subscriber/Filtration/FiltrationSubscriberTest.php
+++ b/tests/Test/Pager/Subscriber/Filtration/FiltrationSubscriberTest.php
@@ -5,14 +5,13 @@ namespace Test\Pager\Subscriber;
 use Knp\Component\Pager\ArgumentAccess\ArgumentAccessInterface;
 use Knp\Component\Pager\Event\BeforeEvent;
 use Knp\Component\Pager\Event\Subscriber\Filtration\FiltrationSubscriber;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Test\Tool\BaseTestCase;
 
 final class FiltrationSubscriberTest extends BaseTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldRegisterExpectedSubscribersOnlyOnce(): void
     {
         $dispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMock();

--- a/tests/Test/Pager/Subscriber/Paginate/ArrayTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/ArrayTest.php
@@ -6,15 +6,14 @@ use Knp\Component\Pager\ArgumentAccess\ArgumentAccessInterface;
 use Knp\Component\Pager\Event\Subscriber\Paginate\ArraySubscriber;
 use Knp\Component\Pager\Pagination\PaginationInterface;
 use Knp\Component\Pager\Paginator;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Test\Mock\PaginationSubscriber as MockPaginationSubscriber;
 use Test\Tool\BaseTestCase;
 
 final class ArrayTest extends BaseTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldPaginateAnArray(): void
     {
         $dispatcher = new EventDispatcher;
@@ -33,9 +32,7 @@ final class ArrayTest extends BaseTestCase
         $this->assertEquals(2, $view->getTotalItemCount());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldSlicePaginateAnArray(): void
     {
         $dispatcher = new EventDispatcher;
@@ -53,9 +50,7 @@ final class ArrayTest extends BaseTestCase
         $this->assertEquals(21, $view->getTotalItemCount());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldSupportPaginateStrategySubscriber(): void
     {
         $items = ['first', 'second'];
@@ -64,9 +59,7 @@ final class ArrayTest extends BaseTestCase
         $this->assertInstanceOf(PaginationInterface::class, $view);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldPaginateArrayObject(): void
     {
         $items = ['first', 'second'];

--- a/tests/Test/Pager/Subscriber/Paginate/Callback/CallbackTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/Callback/CallbackTest.php
@@ -5,6 +5,7 @@ use Knp\Component\Pager\Event\Subscriber\Paginate\Callback\CallbackPagination;
 use Knp\Component\Pager\Event\Subscriber\Paginate\Callback\CallbackSubscriber;
 use Knp\Component\Pager\Pagination\PaginationInterface;
 use Knp\Component\Pager\Paginator;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Test\Mock\PaginationSubscriber as MockPaginationSubscriber;
 use Test\Tool\BaseTestCase;
@@ -14,9 +15,7 @@ final class CallbackTest extends BaseTestCase
     public const ITEMS_PER_PAGE = 10;
     public const TOTAL_NUMBER_OF_ITEMS = 35;
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldPaginate(): void
     {
         $p = $this->givenPaginatorConfigured();
@@ -33,9 +32,7 @@ final class CallbackTest extends BaseTestCase
         $this->assertEquals(self::TOTAL_NUMBER_OF_ITEMS, $view->getTotalItemCount());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldSlicePaginate(): void
     {
         $p = $this->givenPaginatorConfigured();

--- a/tests/Test/Pager/Subscriber/Paginate/Doctrine/CollectionTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/Doctrine/CollectionTest.php
@@ -7,15 +7,14 @@ use Knp\Component\Pager\ArgumentAccess\ArgumentAccessInterface;
 use Knp\Component\Pager\Event\Subscriber\Paginate\Doctrine\CollectionSubscriber;
 use Knp\Component\Pager\Pagination\PaginationInterface;
 use Knp\Component\Pager\Paginator;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Test\Mock\PaginationSubscriber as MockPaginationSubscriber;
 use Test\Tool\BaseTestCase;
 
 final class CollectionTest extends BaseTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldPaginateCollection(): void
     {
         $dispatcher = new EventDispatcher;
@@ -33,9 +32,7 @@ final class CollectionTest extends BaseTestCase
         $this->assertEquals(2, $view->getTotalItemCount());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldLoopOverPagination(): void
     {
         $dispatcher = new EventDispatcher;
@@ -58,9 +55,7 @@ final class CollectionTest extends BaseTestCase
         $this->assertEquals(2, $counter);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldSlicePaginateAnArray(): void
     {
         $dispatcher = new EventDispatcher;
@@ -78,9 +73,7 @@ final class CollectionTest extends BaseTestCase
         $this->assertEquals(21, $view->getTotalItemCount());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldSupportPaginateStrategySubscriber(): void
     {
         $items = new ArrayCollection(['first', 'second']);

--- a/tests/Test/Pager/Subscriber/Paginate/Doctrine/DBALQueryBuilderTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/Doctrine/DBALQueryBuilderTest.php
@@ -3,14 +3,13 @@
 namespace Test\Pager\Subscriber\Paginate\Doctrine;
 
 use Doctrine\DBAL\Query\QueryBuilder;
+use PHPUnit\Framework\Attributes\Test;
 use Test\Fixture\Entity\Article;
 use Test\Tool\BaseTestCaseORM;
 
 final class DBALQueryBuilderTest extends BaseTestCaseORM
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldPaginateSimpleDoctrineQuery(): void
     {
         $this->populate();

--- a/tests/Test/Pager/Subscriber/Paginate/Doctrine/ODM/MongoDB/GridFsTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/Doctrine/ODM/MongoDB/GridFsTest.php
@@ -2,14 +2,13 @@
 
 namespace Test\Pager\Subscriber\Sortable\Doctrine\ODM\MongoDB;
 
+use PHPUnit\Framework\Attributes\Test;
 use Test\Fixture\Document\Image;
 use Test\Tool\BaseTestCaseMongoODM;
 
 final class GridFsTest extends BaseTestCaseMongoODM
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldPaginate(): void
     {
         $this->populate();

--- a/tests/Test/Pager/Subscriber/Paginate/Doctrine/ODM/MongoDB/QueryBuilderTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/Doctrine/ODM/MongoDB/QueryBuilderTest.php
@@ -2,14 +2,13 @@
 
 namespace Test\Pager\Subscriber\Paginate\Doctrine\ODM\MongoDB;
 
+use PHPUnit\Framework\Attributes\Test;
 use Test\Fixture\Document\Article;
 use Test\Tool\BaseTestCaseMongoODM;
 
 final class QueryBuilderTest extends BaseTestCaseMongoODM
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldSupportPaginateStrategySubscriber(): void
     {
         $this->populate();

--- a/tests/Test/Pager/Subscriber/Paginate/Doctrine/ODM/MongoDB/QueryTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/Doctrine/ODM/MongoDB/QueryTest.php
@@ -5,15 +5,14 @@ namespace Test\Pager\Subscriber\Paginate\Doctrine\ODM\MongoDB;
 use Knp\Component\Pager\Event\Subscriber\Paginate\Doctrine\ODM\MongoDB\QuerySubscriber;
 use Knp\Component\Pager\Event\Subscriber\Paginate\PaginationSubscriber;
 use Knp\Component\Pager\Pagination\SlidingPagination;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Test\Fixture\Document\Article;
 use Test\Tool\BaseTestCaseMongoODM;
 
 final class QueryTest extends BaseTestCaseMongoODM
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldPaginateSimpleDoctrineMongoDBQuery(): void
     {
         $this->populate();
@@ -38,9 +37,7 @@ final class QueryTest extends BaseTestCaseMongoODM
         $this->assertEquals('winter', $items[1]->getTitle());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldSupportPaginateStrategySubscriber(): void
     {
         $query = $this

--- a/tests/Test/Pager/Subscriber/Paginate/Doctrine/ODM/PHPCR/QueryBuilderSubscriberTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/Doctrine/ODM/PHPCR/QueryBuilderSubscriberTest.php
@@ -2,14 +2,13 @@
 
 namespace Test\Pager\Subscriber\Paginate\Doctrine\ODM\PHPCR;
 
+use PHPUnit\Framework\Attributes\Test;
 use Test\Fixture\Document\PHPCR\Article;
 use Test\Tool\BaseTestCasePHPCRODM;
 
 final class QueryBuilderSubscriberTest extends BaseTestCasePHPCRODM
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldSupportPaginateStrategySubscriber(): void
     {
         $this->populate();

--- a/tests/Test/Pager/Subscriber/Paginate/Doctrine/ODM/PHPCR/QuerySubscriberTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/Doctrine/ODM/PHPCR/QuerySubscriberTest.php
@@ -6,6 +6,7 @@ use Knp\Component\Pager\ArgumentAccess\ArgumentAccessInterface;
 use Knp\Component\Pager\Event\Subscriber\Paginate\Doctrine\ODM\PHPCR\QuerySubscriber;
 use Knp\Component\Pager\Pagination\SlidingPagination;
 use Knp\Component\Pager\Paginator;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Test\Fixture\Document\PHPCR\Article;
 use Test\Mock\PaginationSubscriber;
@@ -13,9 +14,7 @@ use Test\Tool\BaseTestCasePHPCRODM;
 
 final class QuerySubscriberTest extends BaseTestCasePHPCRODM
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldPaginateSimpleDoctrinePHPCRQuery(): void
     {
         $this->populate();
@@ -42,9 +41,7 @@ final class QuerySubscriberTest extends BaseTestCasePHPCRODM
         $this->assertEquals('winter', $items->last()->getTitle());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldSupportPaginateStrategySubscriber(): void
     {
         $this->getMockDocumentManager();

--- a/tests/Test/Pager/Subscriber/Paginate/Doctrine/ORM/AdvancedQueryTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/Doctrine/ORM/AdvancedQueryTest.php
@@ -3,6 +3,7 @@
 namespace Test\Pager\Subscriber\Paginate\Doctrine\ORM;
 
 use Doctrine\ORM\Query;
+use PHPUnit\Framework\Attributes\Test;
 use Test\Fixture\Entity\Shop\Product;
 use Test\Fixture\Entity\Shop\Tag;
 use Test\Tool\BaseTestCaseORM;
@@ -12,9 +13,8 @@ final class AdvancedQueryTest extends BaseTestCaseORM
     /**
      * It's not possible to make distinction and predict
      * count of such query
-     *
-     * @test
      */
+    #[Test]
     public function shouldFailToPaginateMultiRootQuery(): void
     {
         $this->expectException(\RuntimeException::class);
@@ -33,9 +33,7 @@ final class AdvancedQueryTest extends BaseTestCaseORM
         $view = $p->paginate($q, 1, 2);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldBeAbleToPaginateWithHavingClause(): void
     {
         $this->populate();
@@ -54,9 +52,7 @@ final class AdvancedQueryTest extends BaseTestCaseORM
         $this->assertCount(3, $view);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldBeAbleToPaginateMixedKeyArray(): void
     {
         $this->populate();
@@ -76,9 +72,7 @@ final class AdvancedQueryTest extends BaseTestCaseORM
         $this->assertTrue(isset($items[0]['title']));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldBeAbleToPaginateCaseBasedQuery(): void
     {
         $this->populate();
@@ -118,9 +112,7 @@ final class AdvancedQueryTest extends BaseTestCaseORM
         $this->assertEquals(1, $items[0]['relevance']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldUseOutputWalkersIfHinted(): void
     {
         $this->populate();

--- a/tests/Test/Pager/Subscriber/Paginate/Doctrine/ORM/CompositeKeyTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/Doctrine/ORM/CompositeKeyTest.php
@@ -4,14 +4,13 @@ namespace Test\Pager\Subscriber\Paginate\Doctrine\ORM;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Knp\Component\Pager\Event\Subscriber\Paginate\Doctrine\ORM\QuerySubscriber;
+use PHPUnit\Framework\Attributes\Test;
 use Test\Fixture\Entity\Composite;
 use Test\Tool\BaseTestCaseORM;
 
 final class CompositeKeyTest extends BaseTestCaseORM
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldBeHandledByQueryHintByPassingCount(): void
     {
         $p = $this->getPaginatorInstance();

--- a/tests/Test/Pager/Subscriber/Paginate/Doctrine/ORM/QueryBuilderTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/Doctrine/ORM/QueryBuilderTest.php
@@ -2,14 +2,13 @@
 
 namespace Test\Pager\Subscriber\Paginate\Doctrine\ORM;
 
+use PHPUnit\Framework\Attributes\Test;
 use Test\Fixture\Entity\Article;
 use Test\Tool\BaseTestCaseORM;
 
 final class QueryBuilderTest extends BaseTestCaseORM
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldPaginateSimpleDoctrineQuery(): void
     {
         $this->populate();

--- a/tests/Test/Pager/Subscriber/Paginate/Doctrine/ORM/QueryTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/Doctrine/ORM/QueryTest.php
@@ -4,15 +4,14 @@ namespace Test\Pager\Subscriber\Paginate\Doctrine\ORM;
 
 use Doctrine\ORM\Query;
 use Knp\Component\Pager\Event\Subscriber\Paginate\Doctrine\ORM\QuerySubscriber;
+use PHPUnit\Framework\Attributes\Test;
 use Test\Fixture\Entity\Shop\Product;
 use Test\Fixture\Entity\Shop\Tag;
 use Test\Tool\BaseTestCaseORM;
 
 final class QueryTest extends BaseTestCaseORM
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldUseOutputWalkersIfAskedTo(): void
     {
         $this->populate();
@@ -34,9 +33,7 @@ final class QueryTest extends BaseTestCaseORM
         $this->assertCount(3, $view);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldNotUseOutputWalkersByDefault(): void
     {
         $this->populate();
@@ -56,9 +53,7 @@ final class QueryTest extends BaseTestCaseORM
         $this->assertCount(3, $view);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldFetchJoinCollectionsIfNeeded(): void
     {
         $this->populate();

--- a/tests/Test/Pager/Subscriber/Paginate/PaginationSubscriberTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/PaginationSubscriberTest.php
@@ -5,14 +5,13 @@ namespace Test\Pager\Subscriber\Paginate;
 use Knp\Component\Pager\ArgumentAccess\ArgumentAccessInterface;
 use Knp\Component\Pager\Event\BeforeEvent;
 use Knp\Component\Pager\Event\Subscriber\Paginate\PaginationSubscriber;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Test\Tool\BaseTestCase;
 
 final class PaginationSubscriberTest extends BaseTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldRegisterExpectedSubscribersOnlyOnce(): void
     {
         $dispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMock();

--- a/tests/Test/Pager/Subscriber/Paginate/SolariumQuerySubscriberTest.php
+++ b/tests/Test/Pager/Subscriber/Paginate/SolariumQuerySubscriberTest.php
@@ -5,6 +5,7 @@ namespace Test\Pager\Subscriber\Paginate;
 use Knp\Component\Pager\ArgumentAccess\ArgumentAccessInterface;
 use Knp\Component\Pager\Event\Subscriber\Paginate\SolariumQuerySubscriber;
 use Knp\Component\Pager\Paginator;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
@@ -12,9 +13,7 @@ use Test\Mock\PaginationSubscriber as MockPaginationSubscriber;
 
 final class SolariumQuerySubscriberTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function arrayShouldNotBeHandled(): void
     {
         $this->expectException(\RuntimeException::class);

--- a/tests/Test/Pager/Subscriber/Sortable/ArraySubscriberTest.php
+++ b/tests/Test/Pager/Subscriber/Sortable/ArraySubscriberTest.php
@@ -6,14 +6,14 @@ use Knp\Component\Pager\ArgumentAccess\RequestArgumentAccess;
 use Knp\Component\Pager\Event\ItemsEvent;
 use Knp\Component\Pager\Event\Subscriber\Sortable\ArraySubscriber;
 use Knp\Component\Pager\PaginatorInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use Test\Fixture\TestItem;
 use Test\Tool\BaseTestCase;
 
 final class ArraySubscriberTest extends BaseTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldSort(): void
     {
         $array = [
@@ -43,9 +43,7 @@ final class ArraySubscriberTest extends BaseTestCase
         $this->assertEquals(3, $array[0]['entry']['sortProperty']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldSortWithCustomCallback(): void
     {
         $array = [
@@ -87,9 +85,7 @@ final class ArraySubscriberTest extends BaseTestCase
         $this->assertEquals('hot', $array[0]['name']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldSortEvenWhenTheSortPropertyIsNotAccessible(): void
     {
         $array = [
@@ -119,10 +115,8 @@ final class ArraySubscriberTest extends BaseTestCase
         $this->assertEquals(2, $array[0]['entry']['sortProperty']);
     }
 
-    /**
-     * @test
-     * @dataProvider getItemsData
-     */
+    #[Test]
+    #[DataProvider('getItemsData')]
     public function shouldBeKeptTheOrderWhenSortPropertyDoesNotExist(array $items): void
     {
         $sameSortOrderItems = [

--- a/tests/Test/Pager/Subscriber/Sortable/Doctrine/ODM/MongoDB/AllowListTest.php
+++ b/tests/Test/Pager/Subscriber/Sortable/Doctrine/ODM/MongoDB/AllowListTest.php
@@ -3,14 +3,13 @@
 namespace Test\Pager\Subscriber\Sortable\Doctrine\ODM\MongoDB;
 
 use Knp\Component\Pager\PaginatorInterface;
+use PHPUnit\Framework\Attributes\Test;
 use Test\Fixture\Document\Article;
 use Test\Tool\BaseTestCaseMongoODM;
 
 final class AllowListTest extends BaseTestCaseMongoODM
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldAllowListSortableFields(): void
     {
         $this->expectException(\UnexpectedValueException::class);
@@ -35,9 +34,7 @@ final class AllowListTest extends BaseTestCaseMongoODM
         $view = $p->paginate($query, 1, 10, \compact(PaginatorInterface::SORT_FIELD_ALLOW_LIST));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldSortWithoutSpecificAllowList(): void
     {
         $this->populate();

--- a/tests/Test/Pager/Subscriber/Sortable/Doctrine/ODM/MongoDB/QueryTest.php
+++ b/tests/Test/Pager/Subscriber/Sortable/Doctrine/ODM/MongoDB/QueryTest.php
@@ -6,15 +6,14 @@ use Knp\Component\Pager\ArgumentAccess\RequestArgumentAccess;
 use Knp\Component\Pager\Event\Subscriber\Paginate\PaginationSubscriber;
 use Knp\Component\Pager\Event\Subscriber\Sortable\Doctrine\ODM\MongoDB\QuerySubscriber as Sortable;
 use Knp\Component\Pager\Paginator;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Test\Fixture\Document\Article;
 use Test\Tool\BaseTestCaseMongoODM;
 
 final class QueryTest extends BaseTestCaseMongoODM
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldSortSimpleDoctrineQuery(): void
     {
         $this->populate();
@@ -60,9 +59,7 @@ final class QueryTest extends BaseTestCaseMongoODM
         $this->assertEquals('spring', $items[3]->getTitle());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldSortOnAnyField(): void
     {
         $query = $this

--- a/tests/Test/Pager/Subscriber/Sortable/Doctrine/ORM/AllowListTest.php
+++ b/tests/Test/Pager/Subscriber/Sortable/Doctrine/ORM/AllowListTest.php
@@ -3,14 +3,13 @@
 namespace Test\Pager\Subscriber\Sortable\Doctrine\ORM;
 
 use Knp\Component\Pager\PaginatorInterface;
+use PHPUnit\Framework\Attributes\Test;
 use Test\Fixture\Entity\Article;
 use Test\Tool\BaseTestCaseORM;
 
 final class AllowListTest extends BaseTestCaseORM
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldAllowListSortableFields(): void
     {
         $this->expectException(\UnexpectedValueException::class);
@@ -32,9 +31,7 @@ final class AllowListTest extends BaseTestCaseORM
         $view = $p->paginate($query, 1, 10, \compact(PaginatorInterface::SORT_FIELD_ALLOW_LIST));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldSortWithoutSpecificAllowList(): void
     {
         $this->populate();

--- a/tests/Test/Pager/Subscriber/Sortable/Doctrine/ORM/QueryTest.php
+++ b/tests/Test/Pager/Subscriber/Sortable/Doctrine/ORM/QueryTest.php
@@ -13,15 +13,14 @@ use Knp\Component\Pager\Event\Subscriber\Sortable\Doctrine\ORM\QuerySubscriber a
 use Knp\Component\Pager\Pagination\SlidingPagination;
 use Knp\Component\Pager\Paginator;
 use Knp\Component\Pager\PaginatorInterface;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Test\Fixture\Entity\Article;
 use Test\Tool\BaseTestCaseORM;
 
 final class QueryTest extends BaseTestCaseORM
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldHandleApcQueryCache(): void
     {
         if (!\extension_loaded('apc') || !\ini_get('apc.enable_cli')) {
@@ -59,9 +58,7 @@ final class QueryTest extends BaseTestCaseORM
         $view = $p->paginate($query, 1, 10);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldSortSimpleDoctrineQuery(): void
     {
         $em = $this->getMockSqliteEntityManager();
@@ -92,9 +89,7 @@ final class QueryTest extends BaseTestCaseORM
         $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1, a0_.enabled AS enabled_2 FROM Article a0_ ORDER BY a0_.title ASC LIMIT 10', $executed[1]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldSortSimpleDoctrineQuery2(): void
     {
         $em = $this->getMockSqliteEntityManager();
@@ -125,9 +120,7 @@ final class QueryTest extends BaseTestCaseORM
         $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1, a0_.enabled AS enabled_2 FROM Article a0_ ORDER BY a0_.title DESC LIMIT 10', $executed[1]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldValidateSortableParameters(): void
     {
         $this->expectException(\UnexpectedValueException::class);
@@ -142,9 +135,7 @@ final class QueryTest extends BaseTestCaseORM
         $view = $p->paginate($query, 1, 10);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldSortByAnyAvailableAlias(): void
     {
         $em = $this->getMockSqliteEntityManager();
@@ -168,9 +159,7 @@ final class QueryTest extends BaseTestCaseORM
         $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1, a0_.enabled AS enabled_2, COUNT(a0_.id) AS sclr_3 FROM Article a0_ ORDER BY sclr_3 ASC LIMIT 10', $executed[1]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldWorkWithInitialPaginatorEventDispatcher(): void
     {
         $em = $this->getMockSqliteEntityManager();
@@ -193,9 +182,7 @@ final class QueryTest extends BaseTestCaseORM
         $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1, a0_.enabled AS enabled_2 FROM Article a0_ ORDER BY a0_.title ASC LIMIT 10', $executed[1]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldNotExecuteExtraQueriesWhenCountIsZero(): void
     {
         $query = $this
@@ -212,9 +199,7 @@ final class QueryTest extends BaseTestCaseORM
         $this->assertEquals(2, $this->queryAnalyzer->getNumExecutedQueries());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldNotAcceptArrayParameter(): void
     {
         if (version_compare(InstalledVersions::getVersion('symfony/http-foundation'), '6.0', '<')) {

--- a/tests/Test/Pager/Subscriber/Sortable/SolariumQuerySubscriberTest.php
+++ b/tests/Test/Pager/Subscriber/Sortable/SolariumQuerySubscriberTest.php
@@ -5,15 +5,14 @@ namespace Test\Pager\Subscriber\Sortable;
 use Knp\Component\Pager\ArgumentAccess\ArgumentAccessInterface;
 use Knp\Component\Pager\Event\Subscriber\Sortable\SolariumQuerySubscriber;
 use Knp\Component\Pager\Paginator;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Test\Mock\PaginationSubscriber as MockPaginationSubscriber;
 use Test\Tool\BaseTestCase;
 
 final class SolariumQuerySubscriberTest extends BaseTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function testArrayShouldNotBeHandled(): void
     {
         $this->expectException(\RuntimeException::class);

--- a/tests/Test/Pager/Subscriber/Sortable/SortableSubscriberTest.php
+++ b/tests/Test/Pager/Subscriber/Sortable/SortableSubscriberTest.php
@@ -3,14 +3,13 @@
 use Knp\Component\Pager\ArgumentAccess\ArgumentAccessInterface;
 use Knp\Component\Pager\Event\BeforeEvent;
 use Knp\Component\Pager\Event\Subscriber\Sortable\SortableSubscriber;
+use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Test\Tool\BaseTestCase;
 
 final class SortableSubscriberTest extends BaseTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function shouldRegisterExpectedSubscribersOnlyOnce(): void
     {
         $dispatcher = $this->getMockBuilder(EventDispatcherInterface::class)->getMock();


### PR DESCRIPTION
https://github.com/KnpLabs/knp-components/pull/339 dropped support PHP 8.0 and made it possible to bump the PHPUnit version.