### PR TITLE
Pass `$options` in `knp_pager.before` event

### DIFF
--- a/src/Knp/Component/Pager/Event/BeforeEvent.php
+++ b/src/Knp/Component/Pager/Event/BeforeEvent.php
@@ -15,7 +15,8 @@ final class BeforeEvent extends Event
     public function __construct(
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly ArgumentAccessInterface $argumentAccess,
-        private readonly ?Connection $connection = null
+        private readonly ?Connection $connection = null,
+        private array &$options = [],
     ) {
     }
 
@@ -27,6 +28,11 @@ final class BeforeEvent extends Event
     public function getArgumentAccess(): ArgumentAccessInterface
     {
         return $this->argumentAccess;
+    }
+
+    public function &getOptions(): array
+    {
+        return $this->options;
     }
 
     public function getConnection(): ?Connection

--- a/src/Knp/Component/Pager/Event/BeforeEvent.php
+++ b/src/Knp/Component/Pager/Event/BeforeEvent.php
@@ -12,11 +12,15 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  */
 final class BeforeEvent extends Event
 {
+    /**
+     * @var array<string, mixed>
+     */
+    public array $options = [];
+
     public function __construct(
         private readonly EventDispatcherInterface $eventDispatcher,
         private readonly ArgumentAccessInterface $argumentAccess,
-        private readonly ?Connection $connection = null,
-        private array &$options = [],
+        private readonly ?Connection $connection = null
     ) {
     }
 
@@ -28,11 +32,6 @@ final class BeforeEvent extends Event
     public function getArgumentAccess(): ArgumentAccessInterface
     {
         return $this->argumentAccess;
-    }
-
-    public function &getOptions(): array
-    {
-        return $this->options;
     }
 
     public function getConnection(): ?Connection

--- a/src/Knp/Component/Pager/Paginator.php
+++ b/src/Knp/Component/Pager/Paginator.php
@@ -88,7 +88,7 @@ final class Paginator implements PaginatorInterface
 
         // before pagination start
         $beforeEvent = new Event\BeforeEvent($this->eventDispatcher, $this->argumentAccess, $this->connection);
-        $beforeEvent->options =& $options;
+        $beforeEvent->options = &$options;
         $this->eventDispatcher->dispatch($beforeEvent, 'knp_pager.before');
         // items
         $itemsEvent = new Event\ItemsEvent($offset, $limit);

--- a/src/Knp/Component/Pager/Paginator.php
+++ b/src/Knp/Component/Pager/Paginator.php
@@ -87,7 +87,7 @@ final class Paginator implements PaginatorInterface
         }
 
         // before pagination start
-        $beforeEvent = new Event\BeforeEvent($this->eventDispatcher, $this->argumentAccess, $this->connection);
+        $beforeEvent = new Event\BeforeEvent($this->eventDispatcher, $this->argumentAccess, $this->connection, $options);
         $this->eventDispatcher->dispatch($beforeEvent, 'knp_pager.before');
         // items
         $itemsEvent = new Event\ItemsEvent($offset, $limit);

--- a/src/Knp/Component/Pager/Paginator.php
+++ b/src/Knp/Component/Pager/Paginator.php
@@ -87,7 +87,8 @@ final class Paginator implements PaginatorInterface
         }
 
         // before pagination start
-        $beforeEvent = new Event\BeforeEvent($this->eventDispatcher, $this->argumentAccess, $this->connection, $options);
+        $beforeEvent = new Event\BeforeEvent($this->eventDispatcher, $this->argumentAccess, $this->connection);
+        $beforeEvent->options =& $options;
         $this->eventDispatcher->dispatch($beforeEvent, 'knp_pager.before');
         // items
         $itemsEvent = new Event\ItemsEvent($offset, $limit);

--- a/tests/Test/Pager/PaginatorTest.php
+++ b/tests/Test/Pager/PaginatorTest.php
@@ -2,9 +2,13 @@
 
 namespace Test\Pager;
 
+use Knp\Component\Pager\Event\BeforeEvent;
+use Knp\Component\Pager\Event\ItemsEvent;
 use Knp\Component\Pager\Event\Subscriber\Paginate\PaginationSubscriber;
+use Knp\Component\Pager\Pagination\SlidingPagination;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Test\Tool\BaseTestCase;
 
 final class PaginatorTest extends BaseTestCase
@@ -28,5 +32,46 @@ final class PaginatorTest extends BaseTestCase
 
         $paginator = $this->getPaginatorInstance(null, $dispatcher);
         $paginator->paginate(null, 1, 10);
+    }
+
+    #[Test]
+    public function shouldPassOptionsToBeforeEventSubscriber(): void
+    {
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addSubscriber(new class implements EventSubscriberInterface {
+            public static function getSubscribedEvents(): array
+            {
+                return [
+                    'knp_pager.before' => ['before', 1],
+                ];
+            }
+            public function before(BeforeEvent $event): void
+            {
+                BaseTestCase::assertArrayHasKey('some_option', $event->options);
+                BaseTestCase::assertEquals('value', $event->options['some_option']);
+
+                $event->options['some_option'] = 'changed';
+                $event->options['extra_option'] = 'added';
+            }
+        });
+        $dispatcher->addSubscriber(new class implements EventSubscriberInterface {
+            public static function getSubscribedEvents(): array
+            {
+                return [
+                    'knp_pager.items' => ['items', 1],
+                ];
+            }
+            public function items(ItemsEvent $event): void
+            {
+                BaseTestCase::assertArrayHasKey('some_option', $event->options);
+                BaseTestCase::assertEquals('changed', $event->options['some_option']);
+                BaseTestCase::assertArrayHasKey('extra_option', $event->options);
+                BaseTestCase::assertEquals('added', $event->options['extra_option']);
+            }
+        });
+        $dispatcher->addSubscriber(new PaginationSubscriber());
+        $paginator = $this->getPaginatorInstance(null, $dispatcher);
+
+        $paginator->paginate([], 1, 10, ['some_option' => 'value']);
     }
 }


### PR DESCRIPTION
With this PR I'd like to suggest to pass the `$options` array with the `knp_pager.before` event in a way that makes it possible to modify the options from event subscribers.

Motivating use case:

I'd like to use values for the sort field parameter that do not expose implementation details in the URL. This is necessary to maintain stable URLs. 

For example, instead of using `blog.title+blog.published_date+blog.id` as a value in the sort query parameter, use `title`.

The translation from `title` to the actual sort criteria could take place in a `knp_pager.before` subscriber; however, it would need to be able to access the options, since I need to pass in information about which pagination use case is being executed (the mapping from query parameter to actual sort expression depends on it).

