### PR TITLE
Pass `ArgumentAccess` with the `knp_pager.items` event

### DIFF
--- a/src/Knp/Component/Pager/Event/ItemsEvent.php
+++ b/src/Knp/Component/Pager/Event/ItemsEvent.php
@@ -2,6 +2,7 @@
 
 namespace Knp\Component\Pager\Event;
 
+use Knp\Component\Pager\ArgumentAccess\ArgumentAccessInterface;
 use Symfony\Contracts\EventDispatcher\Event;
 
 /**
@@ -34,7 +35,7 @@ final class ItemsEvent extends Event
      */
     private array $customPaginationParams = [];
 
-    public function __construct(private readonly int $offset, private readonly int $limit)
+    public function __construct(private readonly int $offset, private readonly int $limit, private readonly ArgumentAccessInterface $argumentAccess)
     {
     }
 
@@ -66,5 +67,10 @@ final class ItemsEvent extends Event
     public function getOffset(): int
     {
         return $this->offset;
+    }
+
+    public function getArgumentAccess(): ArgumentAccessInterface
+    {
+        return $this->argumentAccess;
     }
 }

--- a/src/Knp/Component/Pager/Event/ItemsEvent.php
+++ b/src/Knp/Component/Pager/Event/ItemsEvent.php
@@ -35,8 +35,11 @@ final class ItemsEvent extends Event
      */
     private array $customPaginationParams = [];
 
-    public function __construct(private readonly int $offset, private readonly int $limit, private readonly ArgumentAccessInterface $argumentAccess)
-    {
+    public function __construct(
+        private readonly int $offset,
+        private readonly int $limit,
+        private readonly ArgumentAccessInterface $argumentAccess
+    ) {
     }
 
     public function setCustomPaginationParameter(string $name, mixed $value): void

--- a/src/Knp/Component/Pager/Event/Subscriber/Filtration/Doctrine/ORM/QuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Filtration/Doctrine/ORM/QuerySubscriber.php
@@ -13,10 +13,6 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class QuerySubscriber implements EventSubscriberInterface
 {
-    public function __construct(private readonly ArgumentAccessInterface $argumentAccess)
-    {
-    }
-
     public function items(ItemsEvent $event): void
     {
         if (!$event->target instanceof Query) {

--- a/src/Knp/Component/Pager/Event/Subscriber/Filtration/Doctrine/ORM/QuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Filtration/Doctrine/ORM/QuerySubscriber.php
@@ -22,16 +22,18 @@ class QuerySubscriber implements EventSubscriberInterface
         if (!$event->target instanceof Query) {
             return;
         }
-        if (!$this->hasQueryParameter($event->options[PaginatorInterface::FILTER_VALUE_PARAMETER_NAME])) {
+        $argumentAccess = $event->getArgumentAccess();
+
+        if (!$argumentAccess->has($event->options[PaginatorInterface::FILTER_VALUE_PARAMETER_NAME])) {
             return;
         }
-        $filterValue = $this->getQueryParameter($event->options[PaginatorInterface::FILTER_VALUE_PARAMETER_NAME]);
+        $filterValue = $argumentAccess->get($event->options[PaginatorInterface::FILTER_VALUE_PARAMETER_NAME]);
         if ((empty($filterValue) && $filterValue !== '0')) {
             return;
         }
         $filterName = null;
-        if ($this->hasQueryParameter($event->options[PaginatorInterface::FILTER_FIELD_PARAMETER_NAME])) {
-            $filterName = $this->getQueryParameter($event->options[PaginatorInterface::FILTER_FIELD_PARAMETER_NAME]);
+        if ($argumentAccess->has($event->options[PaginatorInterface::FILTER_FIELD_PARAMETER_NAME])) {
+            $filterName = $argumentAccess->get($event->options[PaginatorInterface::FILTER_FIELD_PARAMETER_NAME]);
         }
         if (!empty($filterName)) {
             $columns = $filterName;
@@ -40,7 +42,7 @@ class QuerySubscriber implements EventSubscriberInterface
         } else {
             return;
         }
-        $value = $this->getQueryParameter($event->options[PaginatorInterface::FILTER_VALUE_PARAMETER_NAME]);
+        $value = $argumentAccess->get($event->options[PaginatorInterface::FILTER_VALUE_PARAMETER_NAME]);
         if (str_contains($value, '*')) {
             $value = str_replace('*', '%', $value);
         }
@@ -66,15 +68,5 @@ class QuerySubscriber implements EventSubscriberInterface
         return [
             'knp_pager.items' => ['items', 0],
         ];
-    }
-
-    private function hasQueryParameter(string $name): bool
-    {
-        return $this->argumentAccess->has($name);
-    }
-
-    private function getQueryParameter(string $name): ?string
-    {
-        return $this->argumentAccess->get($name);
     }
 }

--- a/src/Knp/Component/Pager/Event/Subscriber/Filtration/FiltrationSubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Filtration/FiltrationSubscriber.php
@@ -23,7 +23,7 @@ class FiltrationSubscriber implements EventSubscriberInterface
         $dispatcher = $event->getEventDispatcher();
         // hook all standard filtration subscribers
         $dispatcher->addSubscriber(new Doctrine\ORM\QuerySubscriber($event->getArgumentAccess()));
-        $dispatcher->addSubscriber(new PropelQuerySubscriber($event->getArgumentAccess()));
+        $dispatcher->addSubscriber(new PropelQuerySubscriber());
 
         $this->isLoaded = true;
     }

--- a/src/Knp/Component/Pager/Event/Subscriber/Filtration/FiltrationSubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Filtration/FiltrationSubscriber.php
@@ -22,7 +22,7 @@ class FiltrationSubscriber implements EventSubscriberInterface
         /** @var \Symfony\Component\EventDispatcher\EventDispatcherInterface $dispatcher */
         $dispatcher = $event->getEventDispatcher();
         // hook all standard filtration subscribers
-        $dispatcher->addSubscriber(new Doctrine\ORM\QuerySubscriber($event->getArgumentAccess()));
+        $dispatcher->addSubscriber(new Doctrine\ORM\QuerySubscriber());
         $dispatcher->addSubscriber(new PropelQuerySubscriber());
 
         $this->isLoaded = true;

--- a/src/Knp/Component/Pager/Event/Subscriber/Filtration/PropelQuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Filtration/PropelQuerySubscriber.php
@@ -2,7 +2,6 @@
 
 namespace Knp\Component\Pager\Event\Subscriber\Filtration;
 
-use Knp\Component\Pager\ArgumentAccess\ArgumentAccessInterface;
 use Knp\Component\Pager\Event\ItemsEvent;
 use Knp\Component\Pager\Exception\InvalidValueException;
 use Knp\Component\Pager\PaginatorInterface;
@@ -10,19 +9,17 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class PropelQuerySubscriber implements EventSubscriberInterface
 {
-    public function __construct(private readonly ArgumentAccessInterface $argumentAccess)
-    {
-    }
-
     public function items(ItemsEvent $event): void
     {
         $query = $event->target;
+        $argumentAccess = $event->getArgumentAccess();
+        
         if ($query instanceof \ModelCriteria) {
-            if (!$this->argumentAccess->has($event->options[PaginatorInterface::FILTER_VALUE_PARAMETER_NAME])) {
+            if (!$argumentAccess->has($event->options[PaginatorInterface::FILTER_VALUE_PARAMETER_NAME])) {
                 return;
             }
-            if ($this->argumentAccess->has($event->options[PaginatorInterface::FILTER_FIELD_PARAMETER_NAME])) {
-                $columns = $this->argumentAccess->get($event->options[PaginatorInterface::FILTER_FIELD_PARAMETER_NAME]);
+            if ($argumentAccess->has($event->options[PaginatorInterface::FILTER_FIELD_PARAMETER_NAME])) {
+                $columns = $argumentAccess->get($event->options[PaginatorInterface::FILTER_FIELD_PARAMETER_NAME]);
             } elseif (!empty($event->options[PaginatorInterface::DEFAULT_FILTER_FIELDS])) {
                 $columns = $event->options[PaginatorInterface::DEFAULT_FILTER_FIELDS];
             } else {
@@ -39,7 +36,7 @@ class PropelQuerySubscriber implements EventSubscriberInterface
                     }
                 }
             }
-            $value = $this->argumentAccess->get($event->options[PaginatorInterface::FILTER_VALUE_PARAMETER_NAME]);
+            $value = $argumentAccess->get($event->options[PaginatorInterface::FILTER_VALUE_PARAMETER_NAME]);
             $criteria = \Criteria::EQUAL;
             if (str_contains($value, '*')) {
                 $value = str_replace('*', '%', $value);

--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/Doctrine/ODM/MongoDB/QuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/Doctrine/ODM/MongoDB/QuerySubscriber.php
@@ -3,7 +3,6 @@
 namespace Knp\Component\Pager\Event\Subscriber\Sortable\Doctrine\ODM\MongoDB;
 
 use Doctrine\ODM\MongoDB\Query\Query;
-use Knp\Component\Pager\ArgumentAccess\ArgumentAccessInterface;
 use Knp\Component\Pager\Event\ItemsEvent;
 use Knp\Component\Pager\Exception\InvalidValueException;
 use Knp\Component\Pager\PaginatorInterface;
@@ -11,12 +10,10 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class QuerySubscriber implements EventSubscriberInterface
 {
-    public function __construct(private readonly ArgumentAccessInterface $argumentAccess)
-    {
-    }
-
     public function items(ItemsEvent $event): void
     {
+        $argumentAccess = $event->getArgumentAccess();
+
         // Check if the result has already been sorted by another sort subscriber
         $customPaginationParameters = $event->getCustomPaginationParameters();
         if (!empty($customPaginationParameters['sorted']) ) {
@@ -27,9 +24,9 @@ class QuerySubscriber implements EventSubscriberInterface
             $event->setCustomPaginationParameter('sorted', true);
             $sortField = $event->options[PaginatorInterface::SORT_FIELD_PARAMETER_NAME];
             $sortDir = $event->options[PaginatorInterface::SORT_DIRECTION_PARAMETER_NAME];
-            if (null !== $sortField && $this->argumentAccess->has($sortField)) {
-                $field = $this->argumentAccess->get($sortField);
-                $dir = null !== $sortDir && strtolower($this->argumentAccess->get($sortDir)) === 'asc' ? 1 : -1;
+            if (null !== $sortField && $argumentAccess->has($sortField)) {
+                $field = $argumentAccess->get($sortField);
+                $dir = null !== $sortDir && strtolower($argumentAccess->get($sortDir)) === 'asc' ? 1 : -1;
 
                 if (isset($event->options[PaginatorInterface::SORT_FIELD_ALLOW_LIST]) && (!in_array($field, $event->options[PaginatorInterface::SORT_FIELD_ALLOW_LIST]))) {
                     throw new InvalidValueException("Cannot sort by: [$field] this field is not in allow list.");

--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/Doctrine/ORM/QuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/Doctrine/ORM/QuerySubscriber.php
@@ -3,7 +3,6 @@
 namespace Knp\Component\Pager\Event\Subscriber\Sortable\Doctrine\ORM;
 
 use Doctrine\ORM\Query;
-use Knp\Component\Pager\ArgumentAccess\ArgumentAccessInterface;
 use Knp\Component\Pager\Event\ItemsEvent;
 use Knp\Component\Pager\Event\Subscriber\Paginate\Doctrine\ORM\Query\Helper as QueryHelper;
 use Knp\Component\Pager\Event\Subscriber\Sortable\Doctrine\ORM\Query\OrderByWalker;
@@ -13,12 +12,10 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class QuerySubscriber implements EventSubscriberInterface
 {
-    public function __construct(private readonly ArgumentAccessInterface $argumentAccess)
-    {
-    }
-
     public function items(ItemsEvent $event): void
     {
+        $argumentAccess = $event->getArgumentAccess();
+        
         // Check if the result has already been sorted by another sort subscriber
         $customPaginationParameters = $event->getCustomPaginationParameters();
         if (!empty($customPaginationParameters['sorted']) ) {
@@ -29,14 +26,14 @@ class QuerySubscriber implements EventSubscriberInterface
             $event->setCustomPaginationParameter('sorted', true);
             $sortField = $event->options[PaginatorInterface::SORT_FIELD_PARAMETER_NAME];
             $sortDir = $event->options[PaginatorInterface::SORT_DIRECTION_PARAMETER_NAME];
-            if (null !== $sortField && $this->argumentAccess->has($sortField)) {
-                $dir = null !== $sortDir && $this->argumentAccess->has($sortDir) && strtolower($this->argumentAccess->get($sortDir)) === 'asc' ? 'asc' : 'desc';
+            if (null !== $sortField && $argumentAccess->has($sortField)) {
+                $dir = null !== $sortDir && $argumentAccess->has($sortDir) && strtolower($argumentAccess->get($sortDir)) === 'asc' ? 'asc' : 'desc';
 
-                if (isset($event->options[PaginatorInterface::SORT_FIELD_ALLOW_LIST]) && !in_array($this->argumentAccess->get($sortField), $event->options[PaginatorInterface::SORT_FIELD_ALLOW_LIST])) {
-                    throw new InvalidValueException("Cannot sort by: [{$this->argumentAccess->get($sortField)}] this field is not in allow list.");
+                if (isset($event->options[PaginatorInterface::SORT_FIELD_ALLOW_LIST]) && !in_array($argumentAccess->get($sortField), $event->options[PaginatorInterface::SORT_FIELD_ALLOW_LIST])) {
+                    throw new InvalidValueException("Cannot sort by: [{$argumentAccess->get($sortField)}] this field is not in allow list.");
                 }
 
-                $sortFieldParameterNames = $this->argumentAccess->get($sortField);
+                $sortFieldParameterNames = $argumentAccess->get($sortField);
                 $fields = [];
                 $aliases = [];
                 if (!is_string($sortFieldParameterNames)) {

--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/ElasticaQuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/ElasticaQuerySubscriber.php
@@ -4,7 +4,6 @@ namespace Knp\Component\Pager\Event\Subscriber\Sortable;
 
 use Elastica\Query;
 use Elastica\SearchableInterface;
-use Knp\Component\Pager\ArgumentAccess\ArgumentAccessInterface;
 use Knp\Component\Pager\Event\ItemsEvent;
 use Knp\Component\Pager\Exception\InvalidValueException;
 use Knp\Component\Pager\PaginatorInterface;
@@ -12,12 +11,10 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class ElasticaQuerySubscriber implements EventSubscriberInterface
 {
-    public function __construct(private readonly ArgumentAccessInterface $argumentAccess)
-    {
-    }
-
     public function items(ItemsEvent $event): void
     {
+        $argumentAccess = $event->getArgumentAccess();
+        
         // Check if the result has already been sorted by another sort subscriber
         $customPaginationParameters = $event->getCustomPaginationParameters();
         if (!empty($customPaginationParameters['sorted']) ) {
@@ -29,9 +26,9 @@ class ElasticaQuerySubscriber implements EventSubscriberInterface
             $event->setCustomPaginationParameter('sorted', true);
             $sortField = $event->options[PaginatorInterface::SORT_FIELD_PARAMETER_NAME];
             $sortDir = $event->options[PaginatorInterface::SORT_DIRECTION_PARAMETER_NAME];
-            if (null !== $sortField && $this->argumentAccess->has($sortField)) {
-                $field = $this->argumentAccess->get($sortField);
-                $dir   = null !== $sortDir && $this->argumentAccess->has($sortDir) && strtolower($this->argumentAccess->get($sortDir)) === 'asc' ? 'asc' : 'desc';
+            if (null !== $sortField && $argumentAccess->has($sortField)) {
+                $field = $argumentAccess->get($sortField);
+                $dir   = null !== $sortDir && $argumentAccess->has($sortDir) && strtolower($argumentAccess->get($sortDir)) === 'asc' ? 'asc' : 'desc';
 
                 if (isset($event->options[PaginatorInterface::SORT_FIELD_ALLOW_LIST]) && !in_array($field, $event->options[PaginatorInterface::SORT_FIELD_ALLOW_LIST])) {
                     throw new InvalidValueException(sprintf('Cannot sort by: [%s] this field is not in allow list.', $field));

--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/PropelQuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/PropelQuerySubscriber.php
@@ -2,7 +2,6 @@
 
 namespace Knp\Component\Pager\Event\Subscriber\Sortable;
 
-use Knp\Component\Pager\ArgumentAccess\ArgumentAccessInterface;
 use Knp\Component\Pager\Event\ItemsEvent;
 use Knp\Component\Pager\Exception\InvalidValueException;
 use Knp\Component\Pager\PaginatorInterface;
@@ -10,12 +9,10 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class PropelQuerySubscriber implements EventSubscriberInterface
 {
-    public function __construct(private readonly ArgumentAccessInterface $argumentAccess)
-    {
-    }
-
     public function items(ItemsEvent $event): void
     {
+        $argumentAccess = $event->getArgumentAccess();
+        
         // Check if the result has already been sorted by another sort subscriber
         $customPaginationParameters = $event->getCustomPaginationParameters();
         if (!empty($customPaginationParameters['sorted']) ) {
@@ -27,13 +24,13 @@ class PropelQuerySubscriber implements EventSubscriberInterface
             $event->setCustomPaginationParameter('sorted', true);
             $sortField = $event->options[PaginatorInterface::SORT_FIELD_PARAMETER_NAME];
             $sortDir = $event->options[PaginatorInterface::SORT_DIRECTION_PARAMETER_NAME];
-            if (null !== $sortField && $this->argumentAccess->has($sortField)) {
-                $part = $this->argumentAccess->get($sortField);
-                $direction = (null !== $sortDir && $this->argumentAccess->has($sortDir) && strtolower($this->argumentAccess->get($sortDir)) === 'asc')
+            if (null !== $sortField && $argumentAccess->has($sortField)) {
+                $part = $argumentAccess->get($sortField);
+                $direction = (null !== $sortDir && $argumentAccess->has($sortDir) && strtolower($argumentAccess->get($sortDir)) === 'asc')
                                 ? 'asc' : 'desc';
 
-                if (isset($event->options[PaginatorInterface::SORT_FIELD_ALLOW_LIST]) && !in_array($this->argumentAccess->get($sortField), $event->options[PaginatorInterface::SORT_FIELD_ALLOW_LIST])) {
-                    throw new InvalidValueException("Cannot sort by: [{$this->argumentAccess->get($sortField)}] this field is not in allow list.");
+                if (isset($event->options[PaginatorInterface::SORT_FIELD_ALLOW_LIST]) && !in_array($argumentAccess->get($sortField), $event->options[PaginatorInterface::SORT_FIELD_ALLOW_LIST])) {
+                    throw new InvalidValueException("Cannot sort by: [{$argumentAccess->get($sortField)}] this field is not in allow list.");
                 }
 
                 $query->orderBy($part, $direction);

--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/SortableSubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/SortableSubscriber.php
@@ -22,13 +22,12 @@ class SortableSubscriber implements EventSubscriberInterface
         /** @var \Symfony\Component\EventDispatcher\EventDispatcherInterface $dispatcher */
         $dispatcher = $event->getEventDispatcher();
         // hook all standard sortable subscribers
-        $argumentAccess = $event->getArgumentAccess();
-        $dispatcher->addSubscriber(new Doctrine\ORM\QuerySubscriber($argumentAccess));
-        $dispatcher->addSubscriber(new Doctrine\ODM\MongoDB\QuerySubscriber($argumentAccess));
-        $dispatcher->addSubscriber(new ElasticaQuerySubscriber($argumentAccess));
-        $dispatcher->addSubscriber(new PropelQuerySubscriber($argumentAccess));
-        $dispatcher->addSubscriber(new SolariumQuerySubscriber($argumentAccess));
-        $dispatcher->addSubscriber(new ArraySubscriber($argumentAccess));
+        $dispatcher->addSubscriber(new Doctrine\ORM\QuerySubscriber());
+        $dispatcher->addSubscriber(new Doctrine\ODM\MongoDB\QuerySubscriber());
+        $dispatcher->addSubscriber(new ElasticaQuerySubscriber());
+        $dispatcher->addSubscriber(new PropelQuerySubscriber());
+        $dispatcher->addSubscriber(new SolariumQuerySubscriber());
+        $dispatcher->addSubscriber(new ArraySubscriber());
 
         $this->isLoaded = true;
     }

--- a/src/Knp/Component/Pager/Paginator.php
+++ b/src/Knp/Component/Pager/Paginator.php
@@ -91,7 +91,7 @@ final class Paginator implements PaginatorInterface
         $beforeEvent->options = &$options;
         $this->eventDispatcher->dispatch($beforeEvent, 'knp_pager.before');
         // items
-        $itemsEvent = new Event\ItemsEvent($offset, $limit);
+        $itemsEvent = new Event\ItemsEvent($offset, $limit, $this->argumentAccess);
         $itemsEvent->options = &$options;
         $itemsEvent->target = &$target;
         $this->eventDispatcher->dispatch($itemsEvent, 'knp_pager.items');

--- a/tests/Test/Pager/Subscriber/Filtration/Doctrine/ORM/QueryTest.php
+++ b/tests/Test/Pager/Subscriber/Filtration/Doctrine/ORM/QueryTest.php
@@ -412,18 +412,16 @@ final class QueryTest extends BaseTestCaseORM
         $em = $this->getMockSqliteEntityManager();
         $this->populate($em);
 
-        $query = $this->em->createQuery('SELECT a FROM Test\Fixture\Entity\Article a');
-        $query->setHint(QuerySubscriber::HINT_FETCH_JOIN_COLLECTION, false);
-
         $dispatcher = new EventDispatcher();
         $dispatcher->addSubscriber(new PaginationSubscriber());
         $dispatcher->addSubscriber(new Filtration());
-
         $requestStack = $this->createRequestStack(['filterParam' => 'a.id,a.title', 'filterValue' => '*er']);
         $accessor = new RequestArgumentAccess($requestStack);
         $p = new Paginator($dispatcher, $accessor);
 
         $this->startQueryLog();
+        $query = $this->em->createQuery('SELECT a FROM Test\Fixture\Entity\Article a');
+        $query->setHint(QuerySubscriber::HINT_FETCH_JOIN_COLLECTION, false);
         $view = $p->paginate($query, 1, 10);
         $items = $view->getItems();
         $this->assertCount(2, $items);

--- a/tests/Test/Pager/Subscriber/Filtration/Doctrine/ORM/QueryTest.php
+++ b/tests/Test/Pager/Subscriber/Filtration/Doctrine/ORM/QueryTest.php
@@ -412,34 +412,27 @@ final class QueryTest extends BaseTestCaseORM
         $em = $this->getMockSqliteEntityManager();
         $this->populate($em);
 
+        $query = $this->em->createQuery('SELECT a FROM Test\Fixture\Entity\Article a');
+        $query->setHint(QuerySubscriber::HINT_FETCH_JOIN_COLLECTION, false);
+
         $dispatcher = new EventDispatcher();
         $dispatcher->addSubscriber(new PaginationSubscriber());
         $dispatcher->addSubscriber(new Filtration());
+
         $requestStack = $this->createRequestStack(['filterParam' => 'a.id,a.title', 'filterValue' => '*er']);
         $accessor = new RequestArgumentAccess($requestStack);
         $p = new Paginator($dispatcher, $accessor);
 
         $this->startQueryLog();
-        $query = $this->em->createQuery('SELECT a FROM Test\Fixture\Entity\Article a');
-        $query->setHint(QuerySubscriber::HINT_FETCH_JOIN_COLLECTION, false);
         $view = $p->paginate($query, 1, 10);
         $items = $view->getItems();
         $this->assertCount(2, $items);
         $this->assertEquals('summer', $items[0]->getTitle());
         $this->assertEquals('winter', $items[1]->getTitle());
 
-        $requestStack = $this->createRequestStack(['filterParam' => ['a.id', 'a.title'], 'filterValue' => '*er']);
-        $accessor = new RequestArgumentAccess($requestStack);
-        $p = new Paginator($dispatcher, $accessor);
-        $view = $p->paginate($query, 1, 10);
-        $items = $view->getItems();
-        $this->assertCount(2, $items);
-        $this->assertEquals('summer', $items[0]->getTitle());
-        $this->assertEquals('winter', $items[1]->getTitle());
         $executed = $this->queryAnalyzer->getExecutedQueries();
 
         $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1, a0_.enabled AS enabled_2 FROM Article a0_ WHERE a0_.id LIKE \'%er\' OR a0_.title LIKE \'%er\' LIMIT 10', $executed[1]);
-        $this->assertEquals('SELECT a0_.id AS id_0, a0_.title AS title_1, a0_.enabled AS enabled_2 FROM Article a0_ WHERE a0_.id LIKE \'%er\' OR a0_.title LIKE \'%er\' LIMIT 10', $executed[3]);
     }
 
     #[Test]

--- a/tests/Test/Pager/Subscriber/Sortable/ArraySubscriberTest.php
+++ b/tests/Test/Pager/Subscriber/Sortable/ArraySubscriberTest.php
@@ -22,23 +22,19 @@ final class ArraySubscriberTest extends BaseTestCase
             ['entry' => ['sortProperty' => 1]],
         ];
 
-        $itemsEvent = new ItemsEvent(0, 10);
-        $itemsEvent->target = &$array;
-        $itemsEvent->options = [PaginatorInterface::SORT_FIELD_PARAMETER_NAME => 'sort', PaginatorInterface::SORT_DIRECTION_PARAMETER_NAME => 'ord'];
+        $arraySubscriber = new ArraySubscriber();
 
         // test asc sort
-        $requestStack = $this->createRequestStack(['sort' => '[entry][sortProperty]', 'ord' => 'asc']);
-        $accessor = new RequestArgumentAccess($requestStack);
-        $arraySubscriber = new ArraySubscriber($accessor);
+        $itemsEvent = $this->createItemsEvent(['sort' => '[entry][sortProperty]', 'ord' => 'asc']);
+        $itemsEvent->target = &$array;
+
         $arraySubscriber->items($itemsEvent);
         $this->assertEquals(1, $array[0]['entry']['sortProperty']);
 
-        $itemsEvent->unsetCustomPaginationParameter('sorted');
-
         // test desc sort
-        $requestStack = $this->createRequestStack(['sort' => '[entry][sortProperty]', 'ord' => 'desc']);
-        $accessor = new RequestArgumentAccess($requestStack);
-        $arraySubscriber = new ArraySubscriber($accessor);
+        $itemsEvent = $this->createItemsEvent(['sort' => '[entry][sortProperty]', 'ord' => 'desc']);
+        $itemsEvent->target = &$array;
+
         $arraySubscriber->items($itemsEvent);
         $this->assertEquals(3, $array[0]['entry']['sortProperty']);
     }
@@ -52,35 +48,31 @@ final class ArraySubscriberTest extends BaseTestCase
             ['name' => 'hot'],
         ];
 
-        $itemsEvent = new ItemsEvent(0, 10);
-        $itemsEvent->target = &$array;
-        $itemsEvent->options = [
-            PaginatorInterface::SORT_FIELD_PARAMETER_NAME => 'sort',
-            PaginatorInterface::SORT_DIRECTION_PARAMETER_NAME => 'ord',
-            'sortFunction' => static function (&$target, $sortField, $sortDirection): void {
-                \usort($target, static function ($object1, $object2) use ($sortField, $sortDirection) {
-                    if ($object1[$sortField] === $object2[$sortField]) {
-                        return 0;
-                    }
+        $arraySubscriber = new ArraySubscriber();
 
-                    return ($object1[$sortField] === 'hot' ? 1 : -1) * ($sortDirection === 'asc' ? 1 : -1);
-                });
-            },
-        ];
+        $sortFunction = static function (&$target, $sortField, $sortDirection): void {
+            \usort($target, static function ($object1, $object2) use ($sortField, $sortDirection) {
+                if ($object1[$sortField] === $object2[$sortField]) {
+                    return 0;
+                }
+
+                return ($object1[$sortField] === 'hot' ? 1 : -1) * ($sortDirection === 'asc' ? 1 : -1);
+            });
+        };
 
         // test asc sort
-        $requestStack = $this->createRequestStack(['sort' => '.name', 'ord' => 'asc']);
-        $accessor = new RequestArgumentAccess($requestStack);
-        $arraySubscriber = new ArraySubscriber($accessor);
+        $itemsEvent = $this->createItemsEvent(['sort' => '.name', 'ord' => 'asc']);
+        $itemsEvent->target = &$array;
+        $itemsEvent->options['sortFunction'] = $sortFunction;
+
         $arraySubscriber->items($itemsEvent);
         $this->assertEquals('cold', $array[0]['name']);
 
-        $itemsEvent->unsetCustomPaginationParameter('sorted');
-
         // test desc sort
-        $requestStack = $this->createRequestStack(['sort' => '.name', 'ord' => 'desc']);
-        $accessor = new RequestArgumentAccess($requestStack);
-        $arraySubscriber = new ArraySubscriber($accessor);
+        $itemsEvent = $this->createItemsEvent(['sort' => '.name', 'ord' => 'desc']);
+        $itemsEvent->target = &$array;
+        $itemsEvent->options['sortFunction'] = $sortFunction;
+
         $arraySubscriber->items($itemsEvent);
         $this->assertEquals('hot', $array[0]['name']);
     }
@@ -94,23 +86,19 @@ final class ArraySubscriberTest extends BaseTestCase
             ['entry' => ['sortProperty' => 1]],
         ];
 
-        $itemsEvent = new ItemsEvent(0, 10);
-        $itemsEvent->target = &$array;
-        $itemsEvent->options = [PaginatorInterface::SORT_FIELD_PARAMETER_NAME => 'sort', PaginatorInterface::SORT_DIRECTION_PARAMETER_NAME => 'ord'];
+        $arraySubscriber = new ArraySubscriber();
 
         // test asc sort
-        $requestStack = $this->createRequestStack(['sort' => '[entry][sortProperty]', 'ord' => 'asc']);
-        $accessor = new RequestArgumentAccess($requestStack);
-        $arraySubscriber = new ArraySubscriber($accessor);
+        $itemsEvent = $this->createItemsEvent(['sort' => '[entry][sortProperty]', 'ord' => 'asc']);
+        $itemsEvent->target = &$array;
+
         $arraySubscriber->items($itemsEvent);
         $this->assertFalse(isset($array[0]['entry']['sortProperty']));
 
-        $itemsEvent->unsetCustomPaginationParameter('sorted');
-
         // test desc sort
-        $requestStack = $this->createRequestStack(['sort' => '[entry][sortProperty]', 'ord' => 'desc']);
-        $accessor = new RequestArgumentAccess($requestStack);
-        $arraySubscriber = new ArraySubscriber($accessor);
+        $itemsEvent = $this->createItemsEvent(['sort' => '[entry][sortProperty]', 'ord' => 'desc']);
+        $itemsEvent->target = &$array;
+
         $arraySubscriber->items($itemsEvent);
         $this->assertEquals(2, $array[0]['entry']['sortProperty']);
     }
@@ -124,26 +112,20 @@ final class ArraySubscriberTest extends BaseTestCase
             $items[1],
             $items[2],
         ];
-        $itemsEvent = new ItemsEvent(0, 10);
-        $itemsEvent->target = &$items;
-        $itemsEvent->options = [
-            PaginatorInterface::SORT_FIELD_PARAMETER_NAME => 'sort',
-            PaginatorInterface::SORT_DIRECTION_PARAMETER_NAME => 'ord',
-        ];
+
+        $arraySubscriber = new ArraySubscriber();
 
         // test asc sort
-        $requestStack = $this->createRequestStack(['sort' => 'notExistProperty', 'ord' => 'asc']);
-        $accessor = new RequestArgumentAccess($requestStack);
-        $arraySubscriber = new ArraySubscriber($accessor);
+        $itemsEvent = $this->createItemsEvent(['sort' => 'notExistProperty', 'ord' => 'asc']);
+        $itemsEvent->target = &$array;
+
         $arraySubscriber->items($itemsEvent);
         $this->assertSame($sameSortOrderItems, $items);
 
-        $itemsEvent->unsetCustomPaginationParameter('sorted');
-
         // test desc sort
-        $requestStack = $this->createRequestStack(['sort' => 'notExistProperty', 'ord' => 'desc']);
-        $accessor = new RequestArgumentAccess($requestStack);
-        $arraySubscriber = new ArraySubscriber($accessor);
+        $itemsEvent = $this->createItemsEvent(['sort' => 'notExistProperty', 'ord' => 'desc']);
+        $itemsEvent->target = &$array;
+
         $arraySubscriber->items($itemsEvent);
         $this->assertSame($sameSortOrderItems, $items);
     }
@@ -169,5 +151,16 @@ final class ArraySubscriberTest extends BaseTestCase
                 ],
             ],
         ];
+    }
+
+    private function createItemsEvent(array $requestParams = []): ItemsEvent
+    {
+        $requestStack = $this->createRequestStack($requestParams);
+        $accessor = new RequestArgumentAccess($requestStack);
+
+        $event = new ItemsEvent(0, 10, $accessor);
+        $event->options = [PaginatorInterface::SORT_FIELD_PARAMETER_NAME => 'sort', PaginatorInterface::SORT_DIRECTION_PARAMETER_NAME => 'ord'];
+
+        return $event;
     }
 }


### PR DESCRIPTION
This makes it possible for `knp_pager.items` event subscribers to access the pagination parameters, without having to be wired up by a dedicated `knp_pager.before` handler.