### PR TITLE
Prioritize sorted orderBy item when already present in QueryBuilder

### DIFF
--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/Doctrine/ORM/Query/OrderByWalker.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/Doctrine/ORM/Query/OrderByWalker.php
@@ -71,21 +71,20 @@ class OrderByWalker extends TreeWalkerAdapter
             $orderByItem->type = $direction;
 
             if ($AST->orderByClause) {
-                $set = false;
-                foreach ($AST->orderByClause->orderByItems as $item) {
+                $orderByItems = &$AST->orderByClause->orderByItems;
+                foreach ($orderByItems as $orderByIndex => $item) {
                     if (
                         $item->expression instanceof PathExpression &&
                         $item->expression->identificationVariable === $alias &&
                         $item->expression->field === $field
                     ) {
-                        $item->type = $direction;
-                        $set = true;
+                        unset($orderByItems[$orderByIndex]);
+
                         break;
                     }
                 }
-                if (!$set) {
-                    array_unshift($AST->orderByClause->orderByItems, $orderByItem);
-                }
+
+                array_unshift($orderByItems, $orderByItem);
             } else {
                 $AST->orderByClause = new OrderByClause([$orderByItem]);
             }


### PR DESCRIPTION
This MR ensures that a sorted orderBy item is always prioritized as the first in the list, especially when it is already present in the QueryBuilder. This ensures that the query prioritizes the sorted property first, as intended.

The change guarantees that `array_unshift` is always used. When the sorted orderBy item is already present in the QueryBuilder, it removes the duplicate item instead of modifying the direction of the existing one.