### PR TITLE
Allow one sort direction per field in the ORM sortable subscriber

### DIFF
--- a/docs/pager/usage.md
+++ b/docs/pager/usage.md
@@ -122,8 +122,9 @@ $pagination = $paginator->paginate($query, 1/*page number*/, 20/*limit per page*
 
 The same applies to the `sort` and `direction` request parameters, where both are joined
 by a `+`: `?sort=u.lastname%2Bu.firstname&direction=desc%2Basc`. A single direction still
-applies to every field, and when fewer directions than fields are given, the last one is
-repeated for the remaining fields.
+applies to every field, when fewer directions than fields are given the last one is
+repeated for the remaining fields, and any direction beyond the number of fields is
+ignored.
 
 ## Filtering database query results by multiple columns (only Doctrine ORM and Propel)
 

--- a/docs/pager/usage.md
+++ b/docs/pager/usage.md
@@ -111,6 +111,20 @@ $pagination = $paginator->paginate($query, 1/*page number*/, 20/*limit per page*
 The Paginator will add an `ORDER BY` automatically for each attribute for the
 `defaultSortFieldName` option.
 
+Each column can also get its own direction, given in the same order as the fields:
+
+```php
+$pagination = $paginator->paginate($query, 1/*page number*/, 20/*limit per page*/, [
+    'defaultSortFieldName' => ['u.lastname', 'u.firstname'],
+    'defaultSortDirection' => ['desc', 'asc'],
+]);
+```
+
+The same applies to the `sort` and `direction` request parameters, where both are joined
+by a `+`: `?sort=u.lastname%2Bu.firstname&direction=desc%2Basc`. A single direction still
+applies to every field, and when fewer directions than fields are given, the last one is
+repeated for the remaining fields.
+
 ## Filtering database query results by multiple columns (only Doctrine ORM and Propel)
 
 You can also filter the result of a database query by multiple columns.

--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/Doctrine/ORM/Query/OrderByWalker.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/Doctrine/ORM/Query/OrderByWalker.php
@@ -40,7 +40,7 @@ class OrderByWalker extends TreeWalkerAdapter
         $fields = (array)$query->getHint(self::HINT_PAGINATOR_SORT_FIELD);
         $aliases = (array)$query->getHint(self::HINT_PAGINATOR_SORT_ALIAS);
         // One direction per field, but a single one is still accepted and then applies to all of them.
-        $directions = (array)$query->getHint(self::HINT_PAGINATOR_SORT_DIRECTION);
+        $directions = (array) $query->getHint(self::HINT_PAGINATOR_SORT_DIRECTION);
 
         $components = $this->getQueryComponents();
         foreach ($fields as $index => $field) {

--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/Doctrine/ORM/Query/OrderByWalker.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/Doctrine/ORM/Query/OrderByWalker.php
@@ -39,6 +39,8 @@ class OrderByWalker extends TreeWalkerAdapter
         $query = $this->_getQuery();
         $fields = (array)$query->getHint(self::HINT_PAGINATOR_SORT_FIELD);
         $aliases = (array)$query->getHint(self::HINT_PAGINATOR_SORT_ALIAS);
+        // One direction per field, but a single one is still accepted and then applies to all of them.
+        $directions = (array)$query->getHint(self::HINT_PAGINATOR_SORT_DIRECTION);
 
         $components = $this->getQueryComponents();
         foreach ($fields as $index => $field) {
@@ -59,7 +61,7 @@ class OrderByWalker extends TreeWalkerAdapter
                 throw new InvalidValueException("There is no component field [$field] in the given Query");
             }
 
-            $direction = $query->getHint(self::HINT_PAGINATOR_SORT_DIRECTION);
+            $direction = $directions[$index] ?? $directions[array_key_last($directions)];
             if ($alias !== false) {
                 $pathExpression = new PathExpression(PathExpression::TYPE_STATE_FIELD, $alias, $field);
                 $pathExpression->type = PathExpression::TYPE_STATE_FIELD;

--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/Doctrine/ORM/QuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/Doctrine/ORM/QuerySubscriber.php
@@ -38,6 +38,11 @@ class QuerySubscriber implements EventSubscriberInterface
                     throw new InvalidValueException('Cannot sort with array parameter.');
                 }
 
+                $sortDirectionParameterValue = null !== $sortDir && $argumentAccess->has($sortDir) ? $argumentAccess->get($sortDir) : null;
+                if (null !== $sortDirectionParameterValue && !is_string($sortDirectionParameterValue)) {
+                    throw new InvalidValueException('Cannot sort with array parameter.');
+                }
+
                 foreach (explode('+', $sortFieldParameterNames) as $sortFieldParameterName) {
                     $parts = explode('.', $sortFieldParameterName, 2);
 
@@ -48,10 +53,7 @@ class QuerySubscriber implements EventSubscriberInterface
                 }
 
                 $event->target
-                    ->setHint(OrderByWalker::HINT_PAGINATOR_SORT_DIRECTION, $this->resolveDirections(
-                        null !== $sortDir && $argumentAccess->has($sortDir) ? $argumentAccess->get($sortDir) : null,
-                        count($fields)
-                    ))
+                    ->setHint(OrderByWalker::HINT_PAGINATOR_SORT_DIRECTION, $this->resolveDirections($sortDirectionParameterValue, count($fields)))
                     ->setHint(OrderByWalker::HINT_PAGINATOR_SORT_FIELD, $fields)
                     ->setHint(OrderByWalker::HINT_PAGINATOR_SORT_ALIAS, $aliases)
                 ;
@@ -68,12 +70,8 @@ class QuerySubscriber implements EventSubscriberInterface
      *
      * @return list<string>
      */
-    private function resolveDirections(mixed $sortDirectionParameterValue, int $fieldCount): array
+    private function resolveDirections(?string $sortDirectionParameterValue, int $fieldCount): array
     {
-        if (null !== $sortDirectionParameterValue && !is_string($sortDirectionParameterValue)) {
-            throw new InvalidValueException('Cannot sort with array parameter.');
-        }
-
         $directions = [];
         foreach (explode('+', (string) $sortDirectionParameterValue) as $direction) {
             $directions[] = 'asc' === strtolower($direction) ? 'asc' : 'desc';

--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/Doctrine/ORM/QuerySubscriber.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/Doctrine/ORM/QuerySubscriber.php
@@ -27,8 +27,6 @@ class QuerySubscriber implements EventSubscriberInterface
             $sortField = $event->options[PaginatorInterface::SORT_FIELD_PARAMETER_NAME];
             $sortDir = $event->options[PaginatorInterface::SORT_DIRECTION_PARAMETER_NAME];
             if (null !== $sortField && $argumentAccess->has($sortField)) {
-                $dir = null !== $sortDir && $argumentAccess->has($sortDir) && strtolower($argumentAccess->get($sortDir)) === 'asc' ? 'asc' : 'desc';
-
                 if (isset($event->options[PaginatorInterface::SORT_FIELD_ALLOW_LIST]) && !in_array($argumentAccess->get($sortField), $event->options[PaginatorInterface::SORT_FIELD_ALLOW_LIST])) {
                     throw new InvalidValueException("Cannot sort by: [{$argumentAccess->get($sortField)}] this field is not in allow list.");
                 }
@@ -50,7 +48,10 @@ class QuerySubscriber implements EventSubscriberInterface
                 }
 
                 $event->target
-                    ->setHint(OrderByWalker::HINT_PAGINATOR_SORT_DIRECTION, $dir)
+                    ->setHint(OrderByWalker::HINT_PAGINATOR_SORT_DIRECTION, $this->resolveDirections(
+                        null !== $sortDir && $argumentAccess->has($sortDir) ? $argumentAccess->get($sortDir) : null,
+                        count($fields)
+                    ))
                     ->setHint(OrderByWalker::HINT_PAGINATOR_SORT_FIELD, $fields)
                     ->setHint(OrderByWalker::HINT_PAGINATOR_SORT_ALIAS, $aliases)
                 ;
@@ -58,6 +59,31 @@ class QuerySubscriber implements EventSubscriberInterface
                 QueryHelper::addCustomTreeWalker($event->target, OrderByWalker::class);
             }
         }
+    }
+
+    /**
+     * Directions are given the same way as the fields, joined by a "+", and are matched to them by
+     * position. A single direction therefore applies to every field, and a missing one repeats the
+     * last given direction.
+     *
+     * @return list<string>
+     */
+    private function resolveDirections(mixed $sortDirectionParameterValue, int $fieldCount): array
+    {
+        if (null !== $sortDirectionParameterValue && !is_string($sortDirectionParameterValue)) {
+            throw new InvalidValueException('Cannot sort with array parameter.');
+        }
+
+        $directions = [];
+        foreach (explode('+', (string) $sortDirectionParameterValue) as $direction) {
+            $directions[] = 'asc' === strtolower($direction) ? 'asc' : 'desc';
+        }
+
+        $directions = array_pad($directions, $fieldCount, end($directions));
+
+        // Directions in excess are dropped, and the fields were prepended one by one, so the
+        // directions have to follow that same order.
+        return array_reverse(array_slice($directions, 0, $fieldCount));
     }
 
     public static function getSubscribedEvents(): array

--- a/src/Knp/Component/Pager/Paginator.php
+++ b/src/Knp/Component/Pager/Paginator.php
@@ -75,6 +75,11 @@ final class Paginator implements PaginatorInterface
             $options[PaginatorInterface::DEFAULT_SORT_FIELD_NAME] = implode('+', $options[PaginatorInterface::DEFAULT_SORT_FIELD_NAME]);
         }
 
+        // normalize default sort direction, given per field like the field names
+        if (isset($options[PaginatorInterface::DEFAULT_SORT_DIRECTION]) && is_array($options[PaginatorInterface::DEFAULT_SORT_DIRECTION])) {
+            $options[PaginatorInterface::DEFAULT_SORT_DIRECTION] = implode('+', $options[PaginatorInterface::DEFAULT_SORT_DIRECTION]);
+        }
+
         $argumentAccess = $this->argumentAccess;
         
         // default sort field and direction are set based on options (if available)

--- a/tests/Test/Pager/Subscriber/Sortable/Doctrine/ORM/QueryTest.php
+++ b/tests/Test/Pager/Subscriber/Sortable/Doctrine/ORM/QueryTest.php
@@ -121,6 +121,61 @@ final class QueryTest extends BaseTestCaseORM
     }
 
     #[Test]
+    public function shouldSortByMultipleFieldsWithOneDirectionEach(): void
+    {
+        $this->assertOrderBy(
+            ['sort' => 'a.enabled+a.title', 'direction' => 'desc+asc'],
+            'a0_.enabled DESC, a0_.title ASC'
+        );
+    }
+
+    #[Test]
+    public function shouldApplyASingleDirectionToEveryField(): void
+    {
+        $this->assertOrderBy(
+            ['sort' => 'a.enabled+a.title', 'direction' => 'desc'],
+            'a0_.enabled DESC, a0_.title DESC'
+        );
+    }
+
+    #[Test]
+    public function shouldRepeatTheLastDirectionWhenFewerThanTheFields(): void
+    {
+        $this->assertOrderBy(
+            ['sort' => 'a.enabled+a.title+a.id', 'direction' => 'asc+desc'],
+            'a0_.enabled ASC, a0_.title DESC, a0_.id DESC'
+        );
+    }
+
+    #[Test]
+    public function shouldIgnoreTheDirectionsInExcessOfTheFields(): void
+    {
+        $this->assertOrderBy(
+            ['sort' => 'a.enabled', 'direction' => 'asc+desc'],
+            'a0_.enabled ASC'
+        );
+    }
+
+    #[Test]
+    public function shouldAcceptTheDefaultSortDirectionAsAnArray(): void
+    {
+        $em = $this->getMockSqliteEntityManager();
+        $this->populate($em);
+
+        $p = $this->getPaginatorInstance($this->createRequestStack([]));
+
+        $this->startQueryLog();
+        $query = $this->em->createQuery('SELECT a FROM Test\Fixture\Entity\Article a');
+        $p->paginate($query, 1, 10, [
+            PaginatorInterface::DEFAULT_SORT_FIELD_NAME => ['a.enabled', 'a.title'],
+            PaginatorInterface::DEFAULT_SORT_DIRECTION => ['desc', 'asc'],
+        ]);
+
+        $executed = $this->queryAnalyzer->getExecutedQueries();
+        $this->assertStringContainsString('ORDER BY a0_.enabled DESC, a0_.title ASC', end($executed));
+    }
+
+    #[Test]
     public function shouldValidateSortableParameters(): void
     {
         $this->expectException(\UnexpectedValueException::class);
@@ -224,6 +279,30 @@ final class QueryTest extends BaseTestCaseORM
     protected function getUsedEntityFixtures(): array
     {
         return [Article::class];
+    }
+
+    /**
+     * @param array<string, mixed> $requestParameters
+     */
+    private function assertOrderBy(array $requestParameters, string $expectedOrderBy): void
+    {
+        $em = $this->getMockSqliteEntityManager();
+        $this->populate($em);
+
+        $requestStack = $this->createRequestStack($requestParameters);
+        $accessor = new RequestArgumentAccess($requestStack);
+        $dispatcher = new EventDispatcher;
+        $dispatcher->addSubscriber(new PaginationSubscriber);
+        $dispatcher->addSubscriber(new Sortable($accessor));
+        $p = new Paginator($dispatcher, $accessor);
+
+        $this->startQueryLog();
+        $query = $this->em->createQuery('SELECT a FROM Test\\Fixture\\Entity\\Article a');
+        $query->setHint(QuerySubscriber::HINT_FETCH_JOIN_COLLECTION, false);
+        $p->paginate($query, 1, 10);
+
+        $executed = $this->queryAnalyzer->getExecutedQueries();
+        $this->assertStringContainsString('ORDER BY '.$expectedOrderBy, end($executed));
     }
 
     private function populate(EntityManager $em): void


### PR DESCRIPTION
Implements what @garak green-lit in KnpLabs/KnpPaginatorBundle#826, in the two files he pointed at.

The sort field parameter has long accepted several fields joined by a `+`, but the direction stayed a single value applied to all of them. Sorting one column ascending and another descending, the usual way to push `NULL`s to the end of a list, was therefore not possible.

`direction` now takes the same `+` syntax and is matched to the fields by position:

```
?sort=a.enabled%2Ba.title&direction=desc%2Basc   ->   ORDER BY a0_.enabled DESC, a0_.title ASC
```

* a single direction still applies to every field, so nothing changes for existing code;
* fewer directions than fields repeats the last one given;
* directions in excess of the fields are dropped.

`defaultSortDirection` also accepts an array now, symmetrically with `defaultSortFieldName`, which the `Paginator` already flattened the same way:

```php
$paginator->paginate($query, 1, 20, [
    'defaultSortFieldName' => ['u.lastname', 'u.firstname'],
    'defaultSortDirection' => ['desc', 'asc'],
]);
```

Two notes:

* `OrderByWalker::HINT_PAGINATOR_SORT_DIRECTION` is public, so the walker still accepts a plain string there and applies it to every field.
* Nothing is needed on the bundle side for the use case in the issue. `Processor::sortable()` already treats a direction passed through `$params` as fixed and copies it into the link without toggling it, so `{direction: 'desc+asc'}` was producing the right URL all along. Only the ORM side ignored it.

The fields are prepended one by one before being handed to the walker, so the directions are reversed alongside them. That ordering is what the tests pin down, by asserting on the generated SQL.
