### PR TITLE
Enable the cast_spaces rule in the CS config

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -13,6 +13,7 @@ return (new PhpCsFixer\Config())
         '@PHP8x2Migration' => true,
         '@PHPUnit10x0Migration:risky' => true,
         'array_syntax' => ['syntax' => 'short'],
+        'cast_spaces' => true,
         'ordered_imports' => true,
         'declare_strict_types' => false,
         'php_unit_mock_short_will_return' => true,

--- a/src/Knp/Component/Pager/Event/Subscriber/Sortable/Doctrine/ORM/Query/OrderByWalker.php
+++ b/src/Knp/Component/Pager/Event/Subscriber/Sortable/Doctrine/ORM/Query/OrderByWalker.php
@@ -37,8 +37,8 @@ class OrderByWalker extends TreeWalkerAdapter
     public function walkSelectStatement(SelectStatement $AST): void
     {
         $query = $this->_getQuery();
-        $fields = (array)$query->getHint(self::HINT_PAGINATOR_SORT_FIELD);
-        $aliases = (array)$query->getHint(self::HINT_PAGINATOR_SORT_ALIAS);
+        $fields = (array) $query->getHint(self::HINT_PAGINATOR_SORT_FIELD);
+        $aliases = (array) $query->getHint(self::HINT_PAGINATOR_SORT_ALIAS);
 
         $components = $this->getQueryComponents();
         foreach ($fields as $index => $field) {

--- a/tests/Test/Pager/Pagination/TraversableItemsTest.php
+++ b/tests/Test/Pager/Pagination/TraversableItemsTest.php
@@ -16,7 +16,7 @@ final class TraversableItemsTest extends BaseTestCase
         $view = $p->paginate($items, 3, 10);
 
         $view->renderer = static fn($data) => 'custom';
-        $this->assertEquals('custom', (string)$view);
+        $this->assertEquals('custom', (string) $view);
 
         $items = $view->getItems();
         $this->assertInstanceOf(\ArrayObject::class, $items);


### PR DESCRIPTION
Follow-up to the `(array)` remark in #354, where you offered to let me do it.

`cast_spaces` is enabled in the CS config. It normalises three lines in the whole codebase: the two `(array)$query->getHint(...)` in `OrderByWalker` you pointed at, and one `(string)$view` in `TraversableItemsTest`.

Checked with the same image the CI uses (`oskarstark/php-cs-fixer-ga`): 2 of 95 files before, 0 of 95 after.

Heads-up: this touches the two lines right above the one #354 changes in `OrderByWalker`, so whichever lands second may need a trivial rebase.
